### PR TITLE
BaselineHeading bug plus reduce framer verbosity

### DIFF
--- a/piksi_multi_rtk_ros/src/piksi_multi.py
+++ b/piksi_multi_rtk_ros/src/piksi_multi.py
@@ -211,7 +211,7 @@ class PiksiMulti:
         self.init_callback('log', Log,
                            SBP_MSG_LOG, MsgLog, 'level', 'text')
         self.init_callback('baseline_heading', BaselineHeading,
-                           SBP_MSG_BASELINE_HEADING, BaselineHeading, 'tow', 'heading', 'n_sats', 'flags')
+                           SBP_MSG_BASELINE_HEADING, MsgBaselineHeading, 'tow', 'heading', 'n_sats', 'flags')
         self.init_callback('age_of_corrections', AgeOfCorrections,
                            SBP_MSG_AGE_CORRECTIONS, MsgAgeCorrections, 'tow', 'age')
 

--- a/piksi_multi_rtk_ros/src/piksi_multi.py
+++ b/piksi_multi_rtk_ros/src/piksi_multi.py
@@ -85,7 +85,7 @@ class PiksiMulti:
             raise
 
         # Create a handler to connect Piksi driver to callbacks.
-        self.framer = Framer(self.driver.read, self.driver.write, verbose=True)
+        self.framer = Framer(self.driver.read, self.driver.write, verbose=False)
         self.handler = Handler(self.framer)
 
         self.debug_mode = rospy.get_param('~debug_mode', False)


### PR DESCRIPTION
I've fixed two small issues in the driver that I think should be merged upstream.  Please let me know what you think!

The first is to make verbose false on the framer so the driver will not spew errors if the version of SBP used by the driver is behind the firmware version on piksi/duro and the Swift device produces messages that the SBP version and driver are not yet aware of.

The second is to fix a bug that causes the following error when MsgBaselineHeader is received; which seemed like a typo to me.
![screenshot from 2018-02-27 16-45-42](https://user-images.githubusercontent.com/11276774/36806789-01815786-1c76-11e8-90e4-5bbca787fb67.png)

