### PR TITLE
read flags field from type-specific SBP message object

### DIFF
--- a/piksi_multi_rtk_ros/src/piksi_multi.py
+++ b/piksi_multi_rtk_ros/src/piksi_multi.py
@@ -428,7 +428,7 @@ class PiksiMulti:
             for attr in attrs:
                 if attr == 'flags':
                     # Least significat three bits of flags indicate status.
-                    if (msg.flags & 0x07) == 0:
+                    if (sbp_msg.flags & 0x07) == 0:
                         return  # Invalid message, do not publish it.
 
                 setattr(ros_message, attr, getattr(sbp_message, attr))


### PR DESCRIPTION
The flags field should be read from the type-specific SBP message object, previously this line read from 'msg'.