### PR TITLE
adding tcp connection support

### DIFF
--- a/piksi_multi_rtk_ros/cfg/piksi_multi_driver_settings.yaml
+++ b/piksi_multi_rtk_ros/cfg/piksi_multi_driver_settings.yaml
@@ -8,11 +8,11 @@ interface: 'serial'
 base_station_mode: false
 
 # debug_mode: if true, output every topic read by this driver
-# whenever possible, use network broadcast, not global ip broadcast
-# use ifconfig to show network broadcast (or calculate it yourself....).
 debug_mode: false
 
 # broadcast_addr: ip address to use for broadcasting corrections
+# whenever possible, use network broadcast, not global ip broadcast
+# use ifconfig to show network broadcast (or calculate it yourself....).
 broadcast_addr: 192.168.0.255
 
 # broadcast_port: port to use for broadcasting corrections
@@ -41,9 +41,9 @@ var_rtk_fix: [0.0049, 0.0049, 0.01]
 serial_port: '/dev/ttyUSB0'
 
 # baud_rate: defines the rate for the serial connection. This driver uses
-# 234000 as the default. Swift Navigation receivers ship with a
+# 230400 as the default. Swift Navigation receivers ship with a
 # default baud rate of 115200.
-baud_rate: 234000
+baud_rate: 230400
 
 # TCP Settings
 

--- a/piksi_multi_rtk_ros/cfg/piksi_multi_driver_settings.yaml
+++ b/piksi_multi_rtk_ros/cfg/piksi_multi_driver_settings.yaml
@@ -1,16 +1,31 @@
-# General Settings.
-serial_port: '/dev/ttyUSB0'
-baud_rate: 230400
+# General Settings
+
+# interface: specifies the interface over which to connect.
+# supported values are 'serial' and 'tcp'
+# if this value is not valid, the driver will default to serial communication
+interface: 'serial'
+
 base_station_mode: false
-debug_mode: false # if true, output every topic read by this driver
+
+# debug_mode: if true, output every topic read by this driver
 # whenever possible, use network broadcast, not global ip broadcast
 # use ifconfig to show network broadcast (or calculate it yourself....).
+debug_mode: false
+
+# broadcast_addr: ip address to use for broadcasting corrections
 broadcast_addr: 192.168.0.255
+
+# broadcast_port: port to use for broadcasting corrections
 broadcast_port: 26078
-base_station_ip_for_latency_estimation: 192.168.0.1 # ip base station if you want to estimate latency.
+
+# base_station_ip_for_latency_estimation: IP of base station for
+# latency estimation.
+base_station_ip_for_latency_estimation: 192.168.0.1
+
 # Coordinate frame of the GPS receiver with respect to the base link.
 navsatfix_frame_id: 'base_link'
 
+# Covariance Settings
 # Variance to be published in the NavSatFix message (in diagonal part).
 # Single Point Positioning (SPP).
 var_spp: [25.0, 25.0, 64.0]
@@ -18,3 +33,24 @@ var_spp: [25.0, 25.0, 64.0]
 var_rtk_float: [25.0, 25.0, 64.0]
 # RTK fix mode.
 var_rtk_fix: [0.0049, 0.0049, 0.01]
+
+# Serial Settings
+
+# serial_port: defines which serial device to use for communication
+# ex '/dev/ttyUSB0'
+serial_port: '/dev/ttyUSB0'
+
+# baud_rate: defines the rate for the serial connection. This driver uses
+# 234000 as the default. Swift Navigation receivers ship with a
+# default baud rate of 115200.
+baud_rate: 234000
+
+# TCP Settings
+
+# tcp_addr: the IP address of the receiver. By default, Swift Navigation
+# receivers have an IP address of 192.168.0.222.
+tcp_addr: 192.168.0.222
+
+# tcp_port: the port number of the TCP server. By default, Swift Navigation
+# receivers publish SBP data on TCP port 55555.
+tcp_port: 55555

--- a/piksi_multi_rtk_ros/install/install_piksi_multi.sh
+++ b/piksi_multi_rtk_ros/install/install_piksi_multi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 GIT_REPO_LIBSBP=https://github.com/swift-nav/libsbp.git
-REPO_TAG=v2.2.15 #version you want to checkout before installing
+REPO_TAG=v2.3.11 #version you want to checkout before installing
 
 # Sort of reg express used to see if there is another verision on SBP library already installed
 # Adapted from https://stackoverflow.com/questions/6363441/check-if-a-file-exists-with-wildcard-in-shell-script

--- a/piksi_multi_rtk_ros/install/install_piksi_multi.sh
+++ b/piksi_multi_rtk_ros/install/install_piksi_multi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 GIT_REPO_LIBSBP=https://github.com/swift-nav/libsbp.git
-REPO_TAG=v2.3.11 #version you want to checkout before installing
+REPO_TAG=v2.2.15 #version you want to checkout before installing
 
 # Sort of reg express used to see if there is another verision on SBP library already installed
 # Adapted from https://stackoverflow.com/questions/6363441/check-if-a-file-exists-with-wildcard-in-shell-script

--- a/piksi_multi_rtk_ros/src/piksi_multi.py
+++ b/piksi_multi_rtk_ros/src/piksi_multi.py
@@ -89,7 +89,7 @@ class PiksiMulti:
                 raise
         else:
             serial_port = rospy.get_param('~serial_port', '/dev/ttyUSB0')
-            baud_rate = rospy.get_param('~baud_rate', 23400)
+            baud_rate = rospy.get_param('~baud_rate', 230400)
             try:
                 self.driver = PySerialDriver(serial_port, baud=baud_rate)
             except SystemExit:

--- a/piksi_multi_rtk_ros/src/piksi_multi.py
+++ b/piksi_multi_rtk_ros/src/piksi_multi.py
@@ -47,7 +47,7 @@ import collections
 
 
 class PiksiMulti:
-    LIB_SBP_VERSION_MULTI = '2.3.11'  # SBP version used for Piksi Multi.
+    LIB_SBP_VERSION_MULTI = '2.2.15'  # SBP version used for Piksi Multi.
 
     # Geodetic Constants.
     kSemimajorAxis = 6378137


### PR DESCRIPTION
Adding support for connection to receiver over TCP.
Adjusting print statements to be more generic, referencing "Swift receiver" rather than "Piksi" since the driver also supports the Duro receiver.