### PR TITLE
Add Magnetometer topic /piksi/mag_raw

### DIFF
--- a/piksi_multi_rtk_ros/cfg/piksi_multi_driver_settings.yaml
+++ b/piksi_multi_rtk_ros/cfg/piksi_multi_driver_settings.yaml
@@ -47,7 +47,7 @@ serial_port: '/dev/ttyUSB0'
 # baud_rate: defines the rate for the serial connection. This driver uses
 # 230400 as the default. Swift Navigation receivers ship with a
 # default baud rate of 115200.
-baud_rate: 230400
+baud_rate: 115200
 
 # TCP Settings
 

--- a/piksi_multi_rtk_ros/src/piksi_multi.py
+++ b/piksi_multi_rtk_ros/src/piksi_multi.py
@@ -31,6 +31,8 @@ from sbp.orientation import * # WARNING: orientation messages are still draft me
 from sbp.piksi import MsgUartState, SBP_MSG_UART_STATE
 from sbp.settings import *
 from zope.interface.exceptions import Invalid
+# Piksi Multi features as a Magnetometer
+from sbp.mag import *
 # Piksi Multi features an IMU
 from sbp.imu import *
 # At the moment importing 'sbp.version' module causes ValueError: Cannot find the version number!
@@ -217,6 +219,11 @@ class PiksiMulti:
         self.init_callback('vel_ned', VelNed,
                            SBP_MSG_VEL_NED, MsgVelNED,
                            'tow', 'n', 'e', 'd', 'h_accuracy', 'v_accuracy', 'n_sats', 'flags')
+        ### add magnetometer
+        self.init_callback('mag_raw_multi', MagRawMulti,
+                           SBP_MSG_MAG_RAW, MsgMagRaw,
+                           'tow', 'tow_f', 'mag_x', 'mag_y', 'mag_z')
+        ###
         self.init_callback('imu_raw_multi', ImuRawMulti,
                            SBP_MSG_IMU_RAW, MsgImuRaw,
                            'tow', 'tow_f', 'acc_x', 'acc_y', 'acc_z', 'gyr_x', 'gyr_y', 'gyr_z')
@@ -321,6 +328,10 @@ class PiksiMulti:
                                                            BaselineNed, queue_size=10)
         publishers['utc_time_multi'] = rospy.Publisher(rospy.get_name() + '/utc_time',
                                                        UtcTimeMulti, queue_size=10)
+        ### add Magnetometer
+        publishers['mag_raw_multi'] = rospy.Publisher(rospy.get_name() + '/mag_raw',
+                                                      MagRawMulti, queue_size=10)
+        ###
         publishers['imu_raw_multi'] = rospy.Publisher(rospy.get_name() + '/imu_raw',
                                                       ImuRawMulti, queue_size=10)
         publishers['imu_aux_multi'] = rospy.Publisher(rospy.get_name() + '/debug/imu_aux',

--- a/piksi_rtk_msgs/CMakeLists.txt
+++ b/piksi_rtk_msgs/CMakeLists.txt
@@ -29,6 +29,7 @@ add_message_files(
     GpsTime.msg
     GpsTimeMulti.msg
     Heartbeat.msg
+    MagRawMulti.msg
     ImuAuxMulti.msg
     ImuRawMulti.msg
     InfoWifiCorrections.msg

--- a/piksi_rtk_msgs/msg/MagRawMulti.msg
+++ b/piksi_rtk_msgs/msg/MagRawMulti.msg
@@ -1,0 +1,9 @@
+# Raw data from the magnetometer.
+
+Header header
+
+uint32 tow    # Milliseconds since start of GPS week. If the high bit is set, the time is unknown or invalid.
+uint8 tow_f   # Milliseconds since start of GPS week, fractional part.
+int16 mag_x   # Magnetic field in the body frame X axis.
+int16 mag_y   # Magnetic field in the body frame Y axis.
+int16 mag_z   # Magnetic field in the body frame Z axis.


### PR DESCRIPTION
So I did the magnetometer addition and it works on my Piksi. The Piksi multi I am using is based on the Firmware `1.4.10` so I did not test with the latest Firmware available. The topic that will be published is named `/piksi/mag_raw`, I did not name it just `/piksi/mag` because the units and the format does not comply with ROS standards. If you believe that such naming is wrong please feel free to change it.

For usage of the new feature we just need to run the normal launch file that is used for launching Piksi, please note that in the conf. file I have changed baud rate to 115200 baud so maybe that is not the optimal parameter but it works for me.

About backward compatibility I did not test with older version of Piksi Firmware but as long the Piksi is using SBP v.2.3.10 we should be fine.

Best regards,

---

Before opening this pull request, please consider the following **checklist**:

 - For bug fixes:
   - Describe the bug or add a link to the related issue.
   - Ideally include instructions on how to reproduce it.
   - Describe your solution.
 - For new features:
   - Describe the new functionality and provide instructions on how to use it.
   - Make sure this feature is backward compatible (if not please discuss this with either @marco-tranzatto or @kholtmann).

 - For mantainers of this repo:
   - Use Semantic Versioning 2.0.0: https://github.com/ethz-asl/ethz_piksi_ros/issues/19
