### PR TITLE
[Gui] Replace any_worker with ros::Timer.

### DIFF
--- a/ethz_piksi_ros/package.xml
+++ b/ethz_piksi_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ethz_piksi_ros</name>
-  <version>1.6.2</version>
+  <version>1.6.3</version>
   <description>Meta-package for the ethz_piksi_ros repository.</description>
 
   <maintainer email="marcot@ethz.ch">Marco Tranzatto</maintainer>

--- a/piksi_multi_rtk_ros/package.xml
+++ b/piksi_multi_rtk_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>piksi_multi_rtk_ros</name>
-  <version>1.6.2</version>
+  <version>1.6.3</version>
   <description>
     ROS driver for Piksi Multi RTK GPS Receiver.
   </description>

--- a/piksi_rtk_kml/package.xml
+++ b/piksi_rtk_kml/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>piksi_rtk_kml</name>
-  <version>1.6.2</version>
+  <version>1.6.3</version>
   <description>
     ROS node to write KML file from Piksi messages.
   </description>

--- a/piksi_rtk_msgs/package.xml
+++ b/piksi_rtk_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>piksi_rtk_msgs</name>
-  <version>1.6.2</version>
+  <version>1.6.3</version>
   <description>
     Package containing messages for Piksi RTK GPS ROS Driver.
   </description>

--- a/piksi_v2_rtk_ros/package.xml
+++ b/piksi_v2_rtk_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>piksi_v2_rtk_ros</name>
-  <version>1.6.1</version>
+  <version>1.6.3</version>
   <description>
     ROS driver for Piksi V2 RTK GPS Receiver.
   </description>

--- a/rqt_gps_rtk_plugin/CMakeLists.txt
+++ b/rqt_gps_rtk_plugin/CMakeLists.txt
@@ -10,7 +10,6 @@ add_definitions(-std=c++11 -Wall -Werror)
 find_package(catkin REQUIRED COMPONENTS
   rqt_gui
   rqt_gui_cpp
-  any_worker
   piksi_rtk_msgs
   sensor_msgs
 
@@ -58,7 +57,6 @@ catkin_package(
   CATKIN_DEPENDS
     rqt_gui
     rqt_gui_cpp
-    any_worker
     piksi_rtk_msgs
     sensor_msgs
 

--- a/rqt_gps_rtk_plugin/include/rqt_gps_rtk_plugin/GpsRtkPlugin.hpp
+++ b/rqt_gps_rtk_plugin/include/rqt_gps_rtk_plugin/GpsRtkPlugin.hpp
@@ -26,9 +26,6 @@
 #include <piksi_rtk_msgs/AgeOfCorrections.h>
 #include <sensor_msgs/NavSatFix.h>
 
-// worker
-#include <any_worker/Worker.hpp>
-
 constexpr double kSignalStrengthScalingFactor = 4.0;
 
 struct TimeStamps {
@@ -86,7 +83,7 @@ Q_OBJECT
     return scaled_signal_strength;
   }
 
-  bool updateWorkerCb(const any_worker::WorkerEvent& event);
+  void timerCallback(const ros::TimerEvent& e);
 
   //subscribers
   ros::Subscriber piksiReceiverStateSub_;
@@ -114,7 +111,7 @@ Q_OBJECT
   int wifiCorrectionsAvgHz_;
   int numCorrectionsFirstSampleMovingWindow_;
   std::vector<double> altitudes_;
-  std::unique_ptr<any_worker::Worker> updateWorker_;
+  ros::Timer timer_;
   TimeStamps lastMsgStamps_;
   // The max allowed timeout [s] before GUI information is updated with "N/A"
   double maxTimeout_;

--- a/rqt_gps_rtk_plugin/package.xml
+++ b/rqt_gps_rtk_plugin/package.xml
@@ -9,7 +9,6 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>any_worker</depend>
   <depend>rqt_gui</depend>
   <depend>rqt_gui_cpp</depend>
   <depend>piksi_rtk_msgs</depend>

--- a/rqt_gps_rtk_plugin/package.xml
+++ b/rqt_gps_rtk_plugin/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rqt_gps_rtk_plugin</name>
-  <version>1.6.2</version>
+  <version>1.6.3</version>
   <description>The rqt_gps_rtk_plugin package</description>
 
   <maintainer email="kaiho@ethz.ch">Kai Holtmann</maintainer>


### PR DESCRIPTION
Replace the any_worker with the standard ros Timer functionality.

Even though the ros::Timer is *not* a realtime kernel/thread replacement, it is sufficient for this GUI. Additionally, this way people wanting to use this driver (and gui) are not dependent on the any_common repository which is a plus.