### PR TITLE
Feature/kml simple path

### DIFF
--- a/ethz_piksi_ros/package.xml
+++ b/ethz_piksi_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ethz_piksi_ros</name>
-  <version>1.6.3</version>
+  <version>1.7.3</version>
   <description>Meta-package for the ethz_piksi_ros repository.</description>
 
   <maintainer email="marcot@ethz.ch">Marco Tranzatto</maintainer>

--- a/piksi_multi_rtk_ros/package.xml
+++ b/piksi_multi_rtk_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>piksi_multi_rtk_ros</name>
-  <version>1.6.3</version>
+  <version>1.7.3</version>
   <description>
     ROS driver for Piksi Multi RTK GPS Receiver.
   </description>

--- a/piksi_rtk_kml/cfg/piksi_rtk_kml_settings.yaml
+++ b/piksi_rtk_kml/cfg/piksi_rtk_kml_settings.yaml
@@ -1,12 +1,13 @@
 # General Settings.
-sampling_frequency: 1.0         # [Hz]
-
-# KML layout
-kml_file_prefix_name: "Piksi"   # It will be prefixed to KML file name.
-document_name: "PiksiRtkKml"    # Name of the Places shown in Google Earth.
-placemarker_prefix_name: "WP"   # It will be prefixed to each incremental waypoint number.
-
-# Use optional messages/fields
-use_altitude_from_enu: True     # Place 'Point' at the altitude specified in 'enu_point' topic.
+sampling_frequency: 2.0         # [Hz]
+kml_layout: "LineString"        # LineString or Placemark.
+kml_altitude_mode: "absolute"   # relativeToGround, absolute, relativeToSeaFloor, clampToGround, clampToSeaFloor.
+use_altitude_from_enu: False    # Place 'Point' at the altitude specified in 'enu_point' topic. Use kml_altitude_mode = relativeToGround.
 extrude_point: True             # Connect the point to the ground with a line, only if use_altitude_from_enu is True.
 use_heading: True               # If true, heading is added to 'Point' description.
+
+# KML Placemark layout
+placemarker_prefix_name: "WP"   # It will be prefixed to each incremental waypoint number.
+
+# KML LineString layout
+tessellate: 0                   # Breaks the line up into smaller chunks.

--- a/piksi_rtk_kml/launch/offline_ground_vehicle.launch
+++ b/piksi_rtk_kml/launch/offline_ground_vehicle.launch
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+
+<launch>
+
+  <!-- Bag file (including absolute file path) -->
+  <arg name="bagfile"                      default="/home/marco/bags/erl/2017-09-20/gps_erl_2017-09-20-19-08-31.bag"/>
+  <!-- Publishing rate multiplier -->
+  <arg name="publishing_rate_multiplier"   default="200"/>
+  <!-- Use simulation clock -->
+  <arg name="use_sim_time"                 default="true"/>
+
+  <!-- Node to convert Piksi ROS driver output to KML format -->
+  <node pkg="piksi_rtk_kml" type="piksi_rtk_kml" name="piksi_rtk_kml" output="screen">
+    <!-- Load default settings -->
+    <rosparam file="$(find piksi_rtk_kml)/cfg/piksi_rtk_kml_settings.yaml"/>
+
+    <!-- Overwrite default settings, customized for a ground vehicle. -->
+    <param name="kml_layout"              value="LineString"/>
+    <param name="use_altitude_from_enu"   value="False"/>
+    <param name="kml_altitude_mode"       value="clampToGround"/>
+  </node>
+
+  <!-- Play rosbag -->
+  <node name="play_rosbag" pkg="rosbag" type="play" output="screen"
+    args="--clock $(arg bagfile) -r $(arg publishing_rate_multiplier)">
+  </node>
+
+</launch>

--- a/piksi_rtk_kml/package.xml
+++ b/piksi_rtk_kml/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>piksi_rtk_kml</name>
-  <version>1.6.3</version>
+  <version>1.7.3</version>
   <description>
     ROS node to write KML file from Piksi messages.
   </description>

--- a/piksi_rtk_kml/src/piksi_rtk_kml/piksi_rtk_kml.py
+++ b/piksi_rtk_kml/src/piksi_rtk_kml/piksi_rtk_kml.py
@@ -8,6 +8,7 @@
 import rospy
 import roslib.packages
 import time
+from datetime import datetime
 from piksi_rtk_msgs.msg import *
 from sensor_msgs.msg import NavSatFix
 from geometry_msgs.msg import PointStamped
@@ -15,15 +16,23 @@ from geometry_msgs.msg import PointStamped
 
 class PiksiRtkKml:
     kRosPackageName = "piksi_rtk_kml"
+    kAvailableKmlLayouts = ["LineString", "Placemark"]
 
     def __init__(self):
         rospy.init_node('piksi_rtk_kml')
+        # Check requested KML layout
+        self.kml_layout = str(rospy.get_param('~kml_layout', self.kAvailableKmlLayouts[0]))
+        if not self.kml_layout in self.kAvailableKmlLayouts:
+            error_msg = "Requested KML layout %s is not available." % self.kml_layout
+            rospy.logfatal(error_msg)
+            rospy.signal_shutdown(error_msg)
+
         # KML file
         package_path = roslib.packages.get_pkg_dir(self.kRosPackageName)
-        kml_file_name = rospy.get_param('~kml_file_prefix_name', "Piksi") + '-' + time.strftime("%Y-%m-%d-%H-%M-%S")
+        kml_file_name = datetime.utcfromtimestamp(rospy.get_time()).strftime('%Y-%m-%d-%H-%M-%S')
         self.kml_file_path = "%s/kml/%s.kml" % (package_path, kml_file_name)
         self.file_obj = open(self.kml_file_path, 'w')
-        self.file_obj.write(self.kml_head(rospy.get_param('~document_name', "PiksiRtkKml")))
+        self.file_obj.write(self.kml_head(kml_file_name))
 
         # Settings.
         self.sampling_period = 1.0 / rospy.get_param('~sampling_frequency', 1.0)
@@ -31,11 +40,13 @@ class PiksiRtkKml:
         self.extrude_point = rospy.get_param('~extrude_point', False)
         self.use_heading = rospy.get_param('~use_heading', True)
         self.placemarker_prefix_name = rospy.get_param('~placemarker_prefix_name', "WP")
+        self.tessellate = rospy.get_param('~tessellate', 0)
+        self.stick_points_to_ground = rospy.get_param('~stick_points_to_ground', False)
+        self.kml_altitude_mode = rospy.get_param('~kml_altitude_mode', "absolute")
 
-        if self.use_altitude_from_enu:
-            self.kml_altitude_mode = "relativeToGround"
-        else:
-            self.kml_altitude_mode = "absolute"
+        if self.use_altitude_from_enu and self.kml_altitude_mode != "relativeToGround":
+            rospy.logwarn("If you want to use altitude from enu_point_fix topic, \
+                it is recommended to set parameter kml_altitude_mode = 'relativeToGround'")
 
         # Subscribe.
         rospy.Subscriber('piksi/navsatfix_rtk_fix', NavSatFix,
@@ -51,12 +62,18 @@ class PiksiRtkKml:
         self.last_heading = 0.0
         self.time_last_writing = rospy.get_time()
         self.last_enu_altitude = 0.0
+        self.first_navsatfix_received = False
 
         rospy.on_shutdown(self.close_kml_file_handler)
 
         rospy.spin()
 
     def navsatfix_rtk_fix_callback(self, msg):
+
+        if not self.first_navsatfix_received:
+            if self.kml_layout == "LineString":
+                self.file_obj.write(self.kml_linestring_preamble())
+            self.first_navsatfix_received = True
 
         if rospy.get_time() >= (self.time_last_writing + self.sampling_period):
 
@@ -67,6 +84,8 @@ class PiksiRtkKml:
             lon = msg.longitude
             if self.use_altitude_from_enu:
                 alt = self.last_enu_altitude
+            elif self.stick_points_to_ground:
+                alt = 0
             else:
                 alt = msg.altitude
             description = ''
@@ -74,8 +93,13 @@ class PiksiRtkKml:
             if self.heading_received:
                 description = 'Receiver Baseline Heading: ' + str(self.last_heading / 1e3) + " [deg]."
 
-            kml_placemakr_str = self.kml_placemark(waypoint_name, utc_time, lat, lon, alt, description)
-            self.file_obj.write(kml_placemakr_str)
+            kml_string = ""
+            if self.kml_layout == "LineString":
+                kml_string = self.kml_linestring(lat, lon, alt)
+            elif self.kml_layout == "Placemark":
+                kml_string = self.kml_placemark(waypoint_name, utc_time, lat, lon, alt, description)
+
+            self.file_obj.write(kml_string)
 
             self.time_last_writing = rospy.get_time()
 
@@ -87,6 +111,8 @@ class PiksiRtkKml:
         self.last_enu_altitude = msg.point.z
 
     def close_kml_file_handler(self):
+        if self.kml_layout == "LineString":
+            self.file_obj.write(self.kml_linestring_tail())
         self.file_obj.write(self.kml_tail())
         self.file_obj.close()
         rospy.loginfo(rospy.get_name() + ' KML file written in \'%s\'' % self.kml_file_path)
@@ -120,3 +146,37 @@ class PiksiRtkKml:
     </Placemark>
 ''' % (name, timestamp, self.extrude_point,
        self.kml_altitude_mode, lon, lat, alt, description)  # KML wants first lon and then lat.
+
+    def kml_linestring(self, lat, lon, alt=0):
+        # do not put space between numbers and comas!
+        return '''
+          %f,%f,%f''' % (lon, lat, alt) # KML wants first lon and then lat.
+
+    def kml_linestring_preamble(self):
+        return '''
+    <Style id="yellowLineGreenPoly">
+        <LineStyle>
+            <color>ff00ffff</color>
+            <width>25</width>
+        </LineStyle>
+        <PolyStyle>
+            <color>7f00ff00</color>
+        </PolyStyle>
+    </Style>
+    <Placemark>
+      <name>Absolute Extruded</name>
+      <description></description>
+      <styleUrl>#yellowLineGreenPoly</styleUrl>
+      <LineString>
+        <extrude>%d</extrude>
+        <tessellate>%d</tessellate>
+        <altitudeMode>%s</altitudeMode>
+        <coordinates>
+''' % (self.extrude_point, self.tessellate, self.kml_altitude_mode)
+
+    def kml_linestring_tail(self):
+        return '''
+        </coordinates>
+      </LineString>
+    </Placemark>
+'''

--- a/piksi_rtk_kml/src/piksi_rtk_kml/piksi_rtk_kml.py
+++ b/piksi_rtk_kml/src/piksi_rtk_kml/piksi_rtk_kml.py
@@ -84,8 +84,6 @@ class PiksiRtkKml:
             lon = msg.longitude
             if self.use_altitude_from_enu:
                 alt = self.last_enu_altitude
-            elif self.stick_points_to_ground:
-                alt = 0
             else:
                 alt = msg.altitude
             description = ''

--- a/piksi_rtk_msgs/package.xml
+++ b/piksi_rtk_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>piksi_rtk_msgs</name>
-  <version>1.6.3</version>
+  <version>1.7.3</version>
   <description>
     Package containing messages for Piksi RTK GPS ROS Driver.
   </description>

--- a/piksi_v2_rtk_ros/package.xml
+++ b/piksi_v2_rtk_ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>piksi_v2_rtk_ros</name>
-  <version>1.6.3</version>
+  <version>1.7.3</version>
   <description>
     ROS driver for Piksi V2 RTK GPS Receiver.
   </description>

--- a/rqt_gps_rtk_plugin/package.xml
+++ b/rqt_gps_rtk_plugin/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rqt_gps_rtk_plugin</name>
-  <version>1.6.3</version>
+  <version>1.7.3</version>
   <description>The rqt_gps_rtk_plugin package</description>
 
   <maintainer email="kaiho@ethz.ch">Kai Holtmann</maintainer>


### PR DESCRIPTION
Improved KML usage.

- launch file `offline_ground_vehicle` can be used to create offline a KML path, with settings customized for a ground vehicle.
