### PR TITLE
Changed apostrophe to ASCII in device monitor description to fix unicode error

### DIFF
--- a/piksi_rtk_msgs/msg/DeviceMonitor_V2_3_15.msg
+++ b/piksi_rtk_msgs/msg/DeviceMonitor_V2_3_15.msg
@@ -1,4 +1,4 @@
-# This message contains temperature and voltage level measurements from the processor’s monitoring
+# This message contains temperature and voltage level measurements from the processor's monitoring
 # system and the RF frontend die temperature if available.
 
 # Message definition based on libsbp v2.2.15


### PR DESCRIPTION
When running rosbag filter on a bag file created with Piksi topics inside, a unicode decode error occurs breaking the process. It is simply fixed by changing the apostrophe character in device monitor msgs file to the ASCII equivalent.