### PR TITLE
Start handler after all initialization is completed

### DIFF
--- a/piksi_multi_rtk_ros/src/piksi_multi_rtk_ros/piksi_multi.py
+++ b/piksi_multi_rtk_ros/src/piksi_multi_rtk_ros/piksi_multi.py
@@ -196,8 +196,6 @@ class PiksiMulti:
             # Start new thread to periodically ping base station.
             threading.Thread(target=self.ping_base_station_over_wifi).start()
 
-        self.handler.start()
-
         # Handle firmware settings services
         self.last_section_setting_read = []
         self.last_setting_read = []
@@ -212,6 +210,8 @@ class PiksiMulti:
         self.use_gps_time = rospy.get_param('~use_gps_time', False)
         self.utc_times = {}
         self.tow = deque()
+
+        self.handler.start()
 
         # Spin.
         rospy.spin()


### PR DESCRIPTION
Before there were use-before-initialization errors with `self.use_gps_time`. To reproduce I think you just have to start the node and it will throw errors that `PiksiMulti instance has no attribute 'use_gps_time'`. The callbacks are apparently already called before the attribute `use_gps_time` has been initialized.
A solution is to only start the handler after all initialization is finished.