### PR TITLE
Extract fix mode from pos llh status flag.

### DIFF
--- a/piksi_multi_rtk_ros/src/piksi_multi_rtk_ros/piksi_multi.py
+++ b/piksi_multi_rtk_ros/src/piksi_multi_rtk_ros/piksi_multi.py
@@ -707,7 +707,7 @@ class PiksiMulti:
                 stamp = self.tow_to_utc(msg.tow)
 
         # Invalid messages.
-        fix_mode = msg.flags & 0b111 # Lower 4 bits define fix mode.
+        fix_mode = msg.flags & 0b111 # Lower 3 bits define fix mode.
         if fix_mode == PosLlhMulti.FIX_MODE_INVALID:
             return
         # SPP GPS messages.


### PR DESCRIPTION
Adresses https://github.com/ethz-asl/ethz_piksi_ros/issues/96

Currently we do not handle the inertial case in the ROS driver. The driver exits with an error when the status flag of MSG POS LLH (see [page 18](https://www.swiftnav.com/resource-files/Swift%20Navigation%20Binary%20Protocol/v2.6.3/Specification/Swift%20Navigation%20Binary%20Protocol%20Specification%20v2.6.3.pdf)) is checked and INS is enabled. This should fix it.

Can you test this @ihsane-d