### PR TITLE
Feature/systemctl pps sync

### DIFF
--- a/piksi_pps_sync/install/install.sh
+++ b/piksi_pps_sync/install/install.sh
@@ -21,49 +21,6 @@ sudo cp pps-gpio-modprobe.ko /lib/modules/$(uname -r)/kernel/drivers/pps/clients
 sudo depmod
 cd ..
 
-# Install NMEA GPS
-sudo apt install gpsd -y
-echo "Do you wish to configure gpsd? [y or Y to accept]"
-read configure_gpsd
-if [[ $configure_gpsd == "Y" || $configure_gpsd == "y" ]]; then
-  echo "Configuring /etc/default/gpsd"
-  sudo rm /etc/default/gpsd
-  sudo sh -c "tee -a /etc/default/gpsd << END
-# Start the gpsd daemon automatically at boot time.
-START_DAEMON=\"true\"
-# Use USB hotplugging to add new USB devices automatically to the daemon.
-USBAUTO=\"false\"
-# Devices gpsd should collect to at boot time.
-# They need to be read/writeable, either by user gpsd or the group dialout.
-DEVICES=\"${DEVICE}\"
-# Other options you want to pass to gpsd.
-GPSD_OPTIONS=\"-n -r\"
-GPSD_SOCKET=\"/var/run/gpsd.sock\"
-END"
-fi
-
-sudo dpkg-reconfigure gpsd
-
-echo "Do you wish to create and overwrite a new /etc/rc.local? [y or Y to accept]"
-read create_rc_local
-if [[ $create_rc_local == "Y" || $create_rc_local == "y" ]]; then
-  echo "Creating /etc/rc.local"
-  sudo rm /etc/rc.local
-  sudo sh -c "tee -a /etc/rc.local << END
-#!/bin/bash
-
-# Start pps-gpio-modprobe module.
-modprobe pps-gpio-modprobe gpio=${GPIO_PIN}
-# Setting GPS UART
-service gpsd stop
-stty -F ${DEVICE} ${BAUD}
-service gpsd start
-
-exit 0
-END"
-  sudo chmod +x /etc/rc.local
-fi
-
 # Install chrony.
 sudo apt install chrony -y
 
@@ -77,6 +34,59 @@ refclock PPS /dev/pps0 lock NMEA
 refclock SHM 0 delay 0.2 refid NMEA
 END"
 fi
+
+# Install NMEA GPS
+sudo apt install gpsd -y
+echo "Do you wish to configure gpsd? [y or Y to accept]"
+read configure_gpsd
+if [[ $configure_gpsd == "Y" || $configure_gpsd == "y" ]]; then
+  echo "Configuring /etc/systemd/system/gpsd.service"
+  sudo rm /etc/systemd/system/gpsd.service
+  sudo sh -c "tee -a /etc/systemd/system/gpsd.service << END
+[Unit]
+Description=GPS (Global Positioning System) Daemon
+Requires=gpsd.socket
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/bin/stty -F ${DEVICE} ${BAUD}
+ExecStart=/usr/sbin/gpsd -n -r ${DEVICE}
+
+[Install]
+WantedBy=multi-user.target
+WantedBy=chrony.service
+Also=gpsd.socket
+END"
+fi
+
+sudo systemctl daemon-reload
+sudo systemctl enable gpsd.service
+
+# Install PPS
+echo "Do you wish to configure pps? [y or Y to accept]"
+read configure_pps
+if [[ $configure_pps == "Y" || $configure_pps == "y" ]]; then
+  echo "Configuring /etc/systemd/system/pps-modprobe.service"
+  sudo rm /etc/systemd/system/pps-modprobe.service
+  sudo sh -c "tee -a /etc/systemd/system/pps-modprobe.service << END
+[Unit]
+Description=Modprobe pps gpio.
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/sbin/modprobe pps-gpio-modprobe gpio=${GPIO_PIN}
+ExecStop=/sbin/rmmod pps-gpio-modprobe
+
+[Install]
+WantedBy=multi-user.target
+WantedBy=chrony.service
+END"
+fi
+
+sudo systemctl daemon-reload
+sudo systemctl enable pps-gpio-modprobe.service
 
 # Install PPS debug tools.
 sudo apt install pps-tools gpsd-clients -y

--- a/piksi_pps_sync/install/install.sh
+++ b/piksi_pps_sync/install/install.sh
@@ -14,7 +14,7 @@ echo "Setting baud rate to ${BAUD}."
 # Install PPS
 cd ..
 cd pps-gpio-modprobe
-sudo apt-get install linux-headers-$(uname -r)
+sudo apt install linux-headers-$(uname -r) libelf-dev
 make clean
 make
 sudo cp pps-gpio-modprobe.ko /lib/modules/$(uname -r)/kernel/drivers/pps/clients/


### PR DESCRIPTION
As mentioned in https://github.com/ethz-asl/ethz_piksi_ros/pull/88 rc.local is obsolete. This PR changes GPSD and pps_gpio_modprobe to startup using systemd. Hopefully this improves robustness during startup. Tested on Up Squared with GPIO set to pin 432, NMEA connected between UART0 and /dev/ttyS4 at 115200.