### PR TITLE
Refactor/factory classes

### DIFF
--- a/piksi_multi_cpp/CMakeLists.txt
+++ b/piksi_multi_cpp/CMakeLists.txt
@@ -20,6 +20,7 @@ cs_add_library(${PROJECT_NAME}
   src/receiver/receiver_position.cc
   src/receiver/receiver.cc
   src/sbp_callback_handler/sbp_callback_handler.cc
+  src/sbp_callback_handler/sbp_callback_handler_factory.cc
   src/sbp_callback_handler/sbp_callback_handler_heartbeat.cc
 )
 target_link_libraries(${PROJECT_NAME} serialport)

--- a/piksi_multi_cpp/CMakeLists.txt
+++ b/piksi_multi_cpp/CMakeLists.txt
@@ -16,6 +16,7 @@ cs_add_library(${PROJECT_NAME}
   src/device/device_usb.cc
   src/receiver/receiver_attitude.cc
   src/receiver/receiver_base_station.cc
+  src/receiver/receiver_factory.cc
   src/receiver/receiver_position.cc
   src/receiver/receiver.cc
   src/sbp_callback_handler/sbp_callback_handler.cc

--- a/piksi_multi_cpp/CMakeLists.txt
+++ b/piksi_multi_cpp/CMakeLists.txt
@@ -12,6 +12,7 @@ catkin_simple(ALL_DEPS_REQUIRED)
 #############
 cs_add_library(${PROJECT_NAME}
   src/device/device.cc
+  src/device/device_factory.cc
   src/device/device_usb.cc
   src/receiver/receiver_attitude.cc
   src/receiver/receiver_base_station.cc

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device.h
@@ -9,9 +9,9 @@
 
 namespace piksi_multi_cpp {
 
-typedef std::string SerialNumber;
-typedef std::set<SerialNumber> SerialNumbers;
-inline bool equalSerialNumber(const SerialNumber& a, const SerialNumber& b) {
+typedef std::string Identifier;
+typedef std::set<Identifier> Identifiers;
+inline bool identifierEqual(const Identifier& a, const Identifier& b) {
   return a.compare(b) == 0;
 }
 
@@ -19,11 +19,11 @@ class Device {
  public:
   typedef std::shared_ptr<Device> DevicePtr;
 
-  Device(const SerialNumber& sn);
+  Device(const Identifier& id);
   virtual bool open() = 0;
   virtual int32_t read(uint8_t* buff, uint32_t n) const = 0;
   virtual void close() = 0;
-  inline std::string getID() const { return serial_number_; }
+  inline std::string getID() const { return id_; }
 
   // This function will be passed to sbp_process.
   // libsbp is a C interface and does not allow binding a non-static member
@@ -33,7 +33,7 @@ class Device {
   static int32_t read_redirect(uint8_t* buff, uint32_t n, void* context);
 
  protected:
-  SerialNumber serial_number_;
+  Identifier id_;
 };
 
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device.h
@@ -7,22 +7,23 @@
 #include <string>
 #include <vector>
 
-typedef std::string Identifier;
-typedef std::set<Identifier> Identifiers;
-inline bool identifierEqual(const Identifier& a, const Identifier& b) {
+namespace piksi_multi_cpp {
+
+typedef std::string SerialNumber;
+typedef std::set<SerialNumber> SerialNumbers;
+inline bool equalSerialNumber(const SerialNumber& a, const SerialNumber& b) {
   return a.compare(b) == 0;
 }
 
-namespace piksi_multi_cpp {
 class Device {
  public:
   enum DeviceType { kUSB = 0 };
 
-  Device(const Identifier& id);
+  Device(const SerialNumber& sn);
   virtual bool open() = 0;
   virtual int32_t read(uint8_t* buff, uint32_t n) const = 0;
   virtual void close() = 0;
-  inline std::string getID() const { return id_; }
+  inline std::string getID() const { return serial_number_; }
 
   // This function will be passed to sbp_process.
   // libsbp is a C interface and does not allow binding a non-static member
@@ -31,13 +32,11 @@ class Device {
   // WARNING: Requires sbp_state_set_io_context to be called first.
   static int32_t read_redirect(uint8_t* buff, uint32_t n, void* context);
 
-  // Factory method to create all devices.
-  static std::shared_ptr<Device> create(DeviceType type, const Identifier& id);
-  static std::vector<std::shared_ptr<Device>> createAllDevices();
-
  protected:
-  Identifier id_;
+  SerialNumber serial_number_;
 };
+
+typedef std::shared_ptr<Device> DevicePtr;
 }  // namespace piksi_multi_cpp
 
 #endif  // PIKSI_MULTI_CPP_DEVICE_DEVICE_H_

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device.h
@@ -17,6 +17,7 @@ inline bool equalSerialNumber(const SerialNumber& a, const SerialNumber& b) {
 
 class Device {
  public:
+  typedef std::shared_ptr<Device> DevicePtr;
   enum DeviceType { kUSB = 0 };
 
   Device(const SerialNumber& sn);
@@ -36,7 +37,6 @@ class Device {
   SerialNumber serial_number_;
 };
 
-typedef std::shared_ptr<Device> DevicePtr;
 }  // namespace piksi_multi_cpp
 
 #endif  // PIKSI_MULTI_CPP_DEVICE_DEVICE_H_

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device.h
@@ -18,7 +18,6 @@ inline bool equalSerialNumber(const SerialNumber& a, const SerialNumber& b) {
 class Device {
  public:
   typedef std::shared_ptr<Device> DevicePtr;
-  enum DeviceType { kUSB = 0 };
 
   Device(const SerialNumber& sn);
   virtual bool open() = 0;

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device_factory.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device_factory.h
@@ -14,7 +14,7 @@ class DeviceFactory {
   enum DeviceType { kUSB = 0 };
   // Factory method to create a device given DeviceType and Serialnumber.
   static Device::DevicePtr createByDeviceTypeAndSerialNumber(
-      const DeviceType type, const SerialNumber& sn);
+      const DeviceType type, const Identifier& id);
   // Factory method to create all devices autodiscovering all Piksis on all
   // interfaces.
   static std::vector<Device::DevicePtr> createAllDevicesByAutodiscovery();

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device_factory.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device_factory.h
@@ -1,0 +1,23 @@
+#ifndef PIKSI_MULTI_CPP_DEVICE_DEVICE_FACTORY_H_
+#define PIKSI_MULTI_CPP_DEVICE_DEVICE_FACTORY_H_
+
+#include "piksi_multi_cpp/device/device.h"
+
+namespace piksi_multi_cpp {
+/* A factory to help initiating devices at runtime. The factory gives interfaces
+to the user on how he wants to create devices, e.g., autodiscovery, given a
+serial number, interface or port.
+See also http://www.blackwasp.co.uk/FactoryMethod.aspx for more details on
+factories. */
+class DeviceFactory {
+ public:
+  // Factory method to create a device given DeviceType and Serialnumber.
+  static DevicePtr createByDeviceTypeAndSerialNumber(
+      const Device::DeviceType type, const SerialNumber& sn);
+  // Factory method to create all devices autodiscovering all Piksis on all
+  // interfaces.
+  static std::vector<DevicePtr> createAllDevicesByAutodiscovery();
+};
+}  // namespace piksi_multi_cpp
+
+#endif  // PIKSI_MULTI_CPP_DEVICE_DEVICE_FACTORY_H_

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device_factory.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device_factory.h
@@ -11,9 +11,10 @@ See also http://www.blackwasp.co.uk/FactoryMethod.aspx for more details on
 factories. */
 class DeviceFactory {
  public:
+  enum DeviceType { kUSB = 0 };
   // Factory method to create a device given DeviceType and Serialnumber.
   static Device::DevicePtr createByDeviceTypeAndSerialNumber(
-      const Device::DeviceType type, const SerialNumber& sn);
+      const DeviceType type, const SerialNumber& sn);
   // Factory method to create all devices autodiscovering all Piksis on all
   // interfaces.
   static std::vector<Device::DevicePtr> createAllDevicesByAutodiscovery();

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device_factory.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device_factory.h
@@ -12,11 +12,11 @@ factories. */
 class DeviceFactory {
  public:
   // Factory method to create a device given DeviceType and Serialnumber.
-  static DevicePtr createByDeviceTypeAndSerialNumber(
+  static Device::DevicePtr createByDeviceTypeAndSerialNumber(
       const Device::DeviceType type, const SerialNumber& sn);
   // Factory method to create all devices autodiscovering all Piksis on all
   // interfaces.
-  static std::vector<DevicePtr> createAllDevicesByAutodiscovery();
+  static std::vector<Device::DevicePtr> createAllDevicesByAutodiscovery();
 };
 }  // namespace piksi_multi_cpp
 

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device_usb.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device_usb.h
@@ -8,16 +8,16 @@ namespace piksi_multi_cpp {
 
 class DeviceUSB : public Device {
  public:
-  DeviceUSB(const SerialNumber& id);
+  DeviceUSB(const Identifier& id);
 
   // List all unique Piksi multi devices using the usb serial number.
-  static SerialNumbers discoverAllSerialNumbers();
+  static Identifiers discoverAllSerialNumbers();
   bool open() override;
   int32_t read(uint8_t* buff, uint32_t n) const override;
   void close() override;
 
  private:
-  static SerialNumber identifyPiksiAndGetSerialNumber(struct sp_port* port);
+  static Identifier identifyPiksiAndGetSerialNumber(struct sp_port* port);
   static void printDeviceInfo(struct sp_port* port);
   static void printPorts();
   bool allocatePort();

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device_usb.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device_usb.h
@@ -8,16 +8,16 @@ namespace piksi_multi_cpp {
 
 class DeviceUSB : public Device {
  public:
-  DeviceUSB(const Identifier& id);
+  DeviceUSB(const SerialNumber& id);
 
   // List all unique Piksi multi devices using the usb serial number.
-  static Identifiers getAllIdentifiers();
+  static SerialNumbers discoverAllSerialNumbers();
   bool open() override;
   int32_t read(uint8_t* buff, uint32_t n) const override;
   void close() override;
 
  private:
-  static Identifier identifyPiksi(struct sp_port* port);
+  static SerialNumber identifyPiksiAndGetSerialNumber(struct sp_port* port);
   static void printDeviceInfo(struct sp_port* port);
   static void printPorts();
   bool allocatePort();

--- a/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver.h
@@ -36,7 +36,7 @@ class Receiver {
   };
   static std::vector<ReceiverType> kTypeVec;
 
-  Receiver(const ros::NodeHandle& nh, const std::shared_ptr<Device>& device);
+  Receiver(const ros::NodeHandle& nh, const DevicePtr& device);
 
   // Closes device.
   ~Receiver();
@@ -49,14 +49,14 @@ class Receiver {
   // Create receiver by setting node handle, hardware device, and type.
   // Warning: Node handle namespace must be unique for every device.
   static std::shared_ptr<Receiver> create(const ros::NodeHandle& nh,
-                                          const std::shared_ptr<Device>& device,
+                                          const DevicePtr& device,
                                           const ReceiverType type);
 
   // Create receiver from node handle and hardware device. Auto infer type from
   // device.
   // Warning: Node handle namespace must be unique for every device.
-  static std::shared_ptr<Receiver> create(
-      const ros::NodeHandle& nh, const std::shared_ptr<Device>& device);
+  static std::shared_ptr<Receiver> create(const ros::NodeHandle& nh,
+                                          const DevicePtr& device);
 
   // Create all receivers from node handle only. Autodetects connected hardware
   // devices, infers device type from Piksi firmware settings and assigns unique
@@ -68,11 +68,11 @@ class Receiver {
   // ROS node handle in the correct receiver namespace.
   ros::NodeHandle nh_;
   // The actual hardware interface.
-  std::shared_ptr<Device> device_;
+  DevicePtr device_;
 
  private:
   // Infer receiver type from Piksi firmware settings.
-  static ReceiverType inferType(const std::shared_ptr<Device>& dev);
+  static ReceiverType inferType(const DevicePtr& dev);
   static std::string createNameSpace(const ReceiverType type, const size_t id);
 
   // Read device and process SBP callbacks.

--- a/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver.h
@@ -63,7 +63,7 @@ class Receiver {
   // The sbp state.
   std::shared_ptr<sbp_state_t> state_;
   // SBP callbacks common for all receivers.
-  std::vector<std::shared_ptr<SBPCallback>> cb_;
+  std::vector<SBPCallbackHandler::SBPCallbackHandlerPtr> cb_;
 };
 
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver.h
@@ -14,28 +14,10 @@
 
 namespace piksi_multi_cpp {
 
-// This class offers a ROS interface for Piksi Multi receivers. It automatically
-// assigns a type to a device and offers ROS topics and services.
+// This class offers a (ROS) interface for Piksi Multi receivers.
 class Receiver {
  public:
   typedef std::shared_ptr<Receiver> ReceiverPtr;
-  /* The three types of receivers are
-
-  kBaseStationReceiver: The static base station sending out RTK corrections.
-
-  kPositionReceiver: The moving rover receiving RTK corrections from the
-  base station and broadcasting RTK GPS positions.
-
-  kAttitudeReceiver: The moving rover receiving RTK corrections from a moving
-  reference receiver and broadcasting the moving baseline (also referred to as
-  heading). */
-  enum ReceiverType {
-    kBaseStationReceiver = 0,
-    kPositionReceiver,
-    kAttitudeReceiver,
-    kUnknown
-  };
-  static std::vector<ReceiverType> kTypeVec;
 
   Receiver(const ros::NodeHandle& nh, const Device::DevicePtr& device);
 

--- a/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver.h
@@ -18,6 +18,7 @@ namespace piksi_multi_cpp {
 // assigns a type to a device and offers ROS topics and services.
 class Receiver {
  public:
+  typedef std::shared_ptr<Receiver> ReceiverPtr;
   /* The three types of receivers are
 
   kBaseStationReceiver: The static base station sending out RTK corrections.
@@ -36,7 +37,7 @@ class Receiver {
   };
   static std::vector<ReceiverType> kTypeVec;
 
-  Receiver(const ros::NodeHandle& nh, const DevicePtr& device);
+  Receiver(const ros::NodeHandle& nh, const Device::DevicePtr& device);
 
   // Closes device.
   ~Receiver();
@@ -44,37 +45,13 @@ class Receiver {
   // Open device.
   bool init();
 
-  // Factory methods to create receivers.
-
-  // Create receiver by setting node handle, hardware device, and type.
-  // Warning: Node handle namespace must be unique for every device.
-  static std::shared_ptr<Receiver> create(const ros::NodeHandle& nh,
-                                          const DevicePtr& device,
-                                          const ReceiverType type);
-
-  // Create receiver from node handle and hardware device. Auto infer type from
-  // device.
-  // Warning: Node handle namespace must be unique for every device.
-  static std::shared_ptr<Receiver> create(const ros::NodeHandle& nh,
-                                          const DevicePtr& device);
-
-  // Create all receivers from node handle only. Autodetects connected hardware
-  // devices, infers device type from Piksi firmware settings and assigns unique
-  // name spaces.
-  static std::vector<std::shared_ptr<Receiver>> createAllReceivers(
-      const ros::NodeHandle& nh);
-
  protected:
   // ROS node handle in the correct receiver namespace.
   ros::NodeHandle nh_;
   // The actual hardware interface.
-  DevicePtr device_;
+  Device::DevicePtr device_;
 
  private:
-  // Infer receiver type from Piksi firmware settings.
-  static ReceiverType inferType(const DevicePtr& dev);
-  static std::string createNameSpace(const ReceiverType type, const size_t id);
-
   // Read device and process SBP callbacks.
   void process();
   // Start thread that reads device and processes SBP messages. This thread is

--- a/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_factory.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_factory.h
@@ -1,0 +1,42 @@
+#ifndef PIKSI_MULTI_CPP_RECEIVER_RECEIVER_FACTORY_H_
+#define PIKSI_MULTI_CPP_RECEIVER_RECEIVER_FACTORY_H_
+
+#include "piksi_multi_cpp/receiver/receiver.h"
+
+namespace piksi_multi_cpp {
+/* A factory to help initiating receivers at runtime. The factory gives
+interfaces to the user on how he wants to create receivers, e.g., autodiscovery
+of Piksi devices and autonaming of receivers or setting namespace, device and
+receiver type manually.
+See also http://www.blackwasp.co.uk/FactoryMethod.aspx for more details on
+factories. */
+class ReceiverFactory {
+ public:
+  // Factory method to create a receiver by setting node handle, hardware
+  // device, and receiver type.
+  // Warning: Node handle namespace must be unique for every receiver.
+  static Receiver::ReceiverPtr createReceiverByNodeHandleDeviceAndReceiverType(
+      const ros::NodeHandle& nh, const Device::DevicePtr& device,
+      const Receiver::ReceiverType type);
+
+  // Factory method to create a receiver by setting node handle and hardware
+  // device. Receiver type is inferred automatically.
+  // Warning: Node handle namespace must be unique for every receiver.
+  static Receiver::ReceiverPtr createReceiverByNodeHandleAndDevice(
+      const ros::NodeHandle& nh, const Device::DevicePtr& device);
+
+  // Create all receivers from node handle only. Autodetects connected hardware
+  // devices, infers device type from Piksi firmware settings and assigns unique
+  // name spaces.
+  static std::vector<Receiver::ReceiverPtr>
+  createAllReceiversByAutoDiscoveryAndNaming(const ros::NodeHandle& nh);
+
+ private:
+  // Infer receiver type from Piksi firmware settings.
+  static Receiver::ReceiverType inferType(const Device::Device::DevicePtr& dev);
+  static std::string createNameSpace(const Receiver::ReceiverType type,
+                                     const size_t id);
+};
+}  // namespace piksi_multi_cpp
+
+#endif  // PIKSI_MULTI_CPP_RECEIVER_RECEIVER_FACTORY_H_

--- a/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_factory.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_factory.h
@@ -31,14 +31,14 @@ class ReceiverFactory {
   // Factory method to create a receiver by setting node handle, hardware
   // device, and receiver type.
   // Warning: Node handle namespace must be unique for every receiver.
-  static Receiver::ReceiverPtr createReceiverByNodeHandleDeviceAndReceiverType(
+  static Receiver::ReceiverPtr createReceiverByReceiverType(
       const ros::NodeHandle& nh, const Device::DevicePtr& device,
       const ReceiverType type);
 
   // Factory method to create a receiver by setting node handle and hardware
   // device. Receiver type is inferred automatically.
   // Warning: Node handle namespace must be unique for every receiver.
-  static Receiver::ReceiverPtr createReceiverByNodeHandleAndDevice(
+  static Receiver::ReceiverPtr createReceiverByDevice(
       const ros::NodeHandle& nh, const Device::DevicePtr& device);
 
   // Create all receivers from node handle only. Autodetects connected hardware

--- a/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_factory.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_factory.h
@@ -12,12 +12,28 @@ See also http://www.blackwasp.co.uk/FactoryMethod.aspx for more details on
 factories. */
 class ReceiverFactory {
  public:
+  /* The three types of receivers are
+
+  kBaseStationReceiver: The static base station sending out RTK corrections.
+
+  kPositionReceiver: The moving rover receiving RTK corrections from the
+  base station and broadcasting RTK GPS positions.
+
+  kAttitudeReceiver: The moving rover receiving RTK corrections from a moving
+  reference receiver and broadcasting the moving baseline (also referred to as
+  heading). */
+  enum ReceiverType {
+    kBaseStationReceiver = 0,
+    kPositionReceiver,
+    kAttitudeReceiver,
+    kUnknown
+  };
   // Factory method to create a receiver by setting node handle, hardware
   // device, and receiver type.
   // Warning: Node handle namespace must be unique for every receiver.
   static Receiver::ReceiverPtr createReceiverByNodeHandleDeviceAndReceiverType(
       const ros::NodeHandle& nh, const Device::DevicePtr& device,
-      const Receiver::ReceiverType type);
+      const ReceiverType type);
 
   // Factory method to create a receiver by setting node handle and hardware
   // device. Receiver type is inferred automatically.
@@ -33,9 +49,8 @@ class ReceiverFactory {
 
  private:
   // Infer receiver type from Piksi firmware settings.
-  static Receiver::ReceiverType inferType(const Device::Device::DevicePtr& dev);
-  static std::string createNameSpace(const Receiver::ReceiverType type,
-                                     const size_t id);
+  static ReceiverType inferType(const Device::Device::DevicePtr& dev);
+  static std::string createNameSpace(const ReceiverType type, const size_t id);
 };
 }  // namespace piksi_multi_cpp
 

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler.h
@@ -12,17 +12,12 @@ const bool kLatchTopic = true;
 
 // This class handles the callback creation for the different piksi message
 // types.
-class SBPCallback {
+class SBPCallbackHandler {
  public:
+  typedef std::shared_ptr<SBPCallbackHandler> SBPCallbackHandlerPtr;
   // Register callback.
-  SBPCallback(const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
-           const std::shared_ptr<sbp_state_t>& state);
-
-  // Factory method to create callbacks.
-  // Add new message types here.
-  static std::shared_ptr<SBPCallback> create(
-      const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
-      const std::shared_ptr<sbp_state_t>& state);
+  SBPCallbackHandler(const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
+                     const std::shared_ptr<sbp_state_t>& state);
 
  protected:
   // Implement the specific callback here.

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_factory.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_factory.h
@@ -12,9 +12,10 @@ factories. */
 class SBPCallbackHandlerFactory {
  public:
   // Factory method to create a callback that relays a specified sbp_msg_type.
-  static SBPCallbackHandler::SBPCallbackHandlerPtr createSBPRelayCallbackBySBPMsgType(
-      const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
-      const std::shared_ptr<sbp_state_t>& state);
+  static SBPCallbackHandler::SBPCallbackHandlerPtr
+  createRelayCallbackBySBPMsgType(const ros::NodeHandle& nh,
+                                  const uint16_t sbp_msg_type,
+                                  const std::shared_ptr<sbp_state_t>& state);
 };
 }  // namespace piksi_multi_cpp
 

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_factory.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_factory.h
@@ -1,0 +1,21 @@
+#ifndef PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_FACTORY_H_
+#define PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_FACTORY_H_
+
+#include "piksi_multi_cpp/receiver/receiver.h"
+
+namespace piksi_multi_cpp {
+/* A factory to help initiating sbp callback handlers at runtime.
+A possible usecase is where the receiver wants to relay all messages currently
+outputted by the Piksi.
+See also http://www.blackwasp.co.uk/FactoryMethod.aspx for more details on
+factories. */
+class SBPCallbackHandlerFactory {
+ public:
+  // Factory method to create a callback that relays a specified sbp_msg_type.
+  static SBPCallbackHandler::SBPCallbackHandlerPtr createSBPRelayCallbackBySBPMsgType(
+      const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
+      const std::shared_ptr<sbp_state_t>& state);
+};
+}  // namespace piksi_multi_cpp
+
+#endif  // PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_FACTORY_H_

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_heartbeat.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_heartbeat.h
@@ -7,7 +7,7 @@
 
 namespace piksi_multi_cpp {
 
-class SBPCallbackHeartbeat : public SBPCallback {
+class SBPCallbackHeartbeat : public SBPCallbackHandler {
  public:
   SBPCallbackHeartbeat(const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
                        const std::shared_ptr<sbp_state_t>& state);

--- a/piksi_multi_cpp/src/device/device.cc
+++ b/piksi_multi_cpp/src/device/device.cc
@@ -3,7 +3,6 @@
 #include <ros/console.h>
 #include <memory>
 #include <vector>
-#include "piksi_multi_cpp/device/device_usb.h"
 
 namespace piksi_multi_cpp {
 

--- a/piksi_multi_cpp/src/device/device.cc
+++ b/piksi_multi_cpp/src/device/device.cc
@@ -6,7 +6,7 @@
 
 namespace piksi_multi_cpp {
 
-Device::Device(const SerialNumber& sn) : serial_number_(sn) {}
+Device::Device(const Identifier& id) : id_(id) {}
 
 int32_t Device::read_redirect(uint8_t* buff, uint32_t n, void* context) {
   if (!context) {

--- a/piksi_multi_cpp/src/device/device.cc
+++ b/piksi_multi_cpp/src/device/device.cc
@@ -7,7 +7,7 @@
 
 namespace piksi_multi_cpp {
 
-Device::Device(const Identifier& id) : id_(id) {}
+Device::Device(const SerialNumber& sn) : serial_number_(sn) {}
 
 int32_t Device::read_redirect(uint8_t* buff, uint32_t n, void* context) {
   if (!context) {
@@ -18,28 +18,6 @@ int32_t Device::read_redirect(uint8_t* buff, uint32_t n, void* context) {
   Device* instance = static_cast<Device*>(context);
   // Execute instance's read function.
   return instance->read(buff, n);
-}
-
-std::shared_ptr<Device> Device::create(DeviceType type, const Identifier& id) {
-  if (type == DeviceType::kUSB) {
-    return std::shared_ptr<Device>(new DeviceUSB(id));
-  } else {
-    return nullptr;
-  }
-}
-
-std::vector<std::shared_ptr<Device>> Device::createAllDevices() {
-  std::vector<std::shared_ptr<Device>> devices;
-
-  // Create all USB devices.
-  Identifiers usb_ids = DeviceUSB::getAllIdentifiers();
-  for (auto id : usb_ids) {
-    auto dev = create(DeviceType::kUSB, id);
-    if (dev.get()) devices.push_back(dev);
-  }
-
-  ROS_WARN_COND(devices.empty(), "No device created.");
-  return devices;
 }
 
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/device/device_factory.cc
+++ b/piksi_multi_cpp/src/device/device_factory.cc
@@ -5,17 +5,17 @@
 
 namespace piksi_multi_cpp {
 
-DevicePtr DeviceFactory::createByDeviceTypeAndSerialNumber(
+Device::DevicePtr DeviceFactory::createByDeviceTypeAndSerialNumber(
     Device::DeviceType type, const SerialNumber& sn) {
   if (type == Device::DeviceType::kUSB) {
-    return DevicePtr(new DeviceUSB(sn));
+    return Device::DevicePtr(new DeviceUSB(sn));
   } else {
     return nullptr;
   }
 }
 
-std::vector<DevicePtr> DeviceFactory::createAllDevicesByAutodiscovery() {
-  std::vector<DevicePtr> devices;
+std::vector<Device::DevicePtr> DeviceFactory::createAllDevicesByAutodiscovery() {
+  std::vector<Device::DevicePtr> devices;
 
   // Create all USB devices.
   SerialNumbers sns = DeviceUSB::discoverAllSerialNumbers();

--- a/piksi_multi_cpp/src/device/device_factory.cc
+++ b/piksi_multi_cpp/src/device/device_factory.cc
@@ -6,9 +6,9 @@
 namespace piksi_multi_cpp {
 
 Device::DevicePtr DeviceFactory::createByDeviceTypeAndSerialNumber(
-    DeviceType type, const SerialNumber& sn) {
+    DeviceType type, const Identifier& id) {
   if (type == DeviceType::kUSB) {
-    return Device::DevicePtr(new DeviceUSB(sn));
+    return Device::DevicePtr(new DeviceUSB(id));
   } else {
     return nullptr;
   }
@@ -19,9 +19,9 @@ DeviceFactory::createAllDevicesByAutodiscovery() {
   std::vector<Device::DevicePtr> devices;
 
   // Create all USB devices.
-  SerialNumbers sns = DeviceUSB::discoverAllSerialNumbers();
-  for (auto sn : sns) {
-    auto dev = createByDeviceTypeAndSerialNumber(DeviceType::kUSB, sn);
+  Identifiers ids = DeviceUSB::discoverAllSerialNumbers();
+  for (auto id : ids) {
+    auto dev = createByDeviceTypeAndSerialNumber(DeviceType::kUSB, id);
     if (dev.get()) devices.push_back(dev);
   }
 

--- a/piksi_multi_cpp/src/device/device_factory.cc
+++ b/piksi_multi_cpp/src/device/device_factory.cc
@@ -1,0 +1,31 @@
+#include <ros/console.h>
+#include "piksi_multi_cpp/device/device.h"
+#include "piksi_multi_cpp/device/device_factory.h"
+#include "piksi_multi_cpp/device/device_usb.h"
+
+namespace piksi_multi_cpp {
+
+DevicePtr DeviceFactory::createByDeviceTypeAndSerialNumber(
+    Device::DeviceType type, const SerialNumber& sn) {
+  if (type == Device::DeviceType::kUSB) {
+    return DevicePtr(new DeviceUSB(sn));
+  } else {
+    return nullptr;
+  }
+}
+
+std::vector<DevicePtr> DeviceFactory::createAllDevicesByAutodiscovery() {
+  std::vector<DevicePtr> devices;
+
+  // Create all USB devices.
+  SerialNumbers sns = DeviceUSB::discoverAllSerialNumbers();
+  for (auto sn : sns) {
+    auto dev = createByDeviceTypeAndSerialNumber(Device::DeviceType::kUSB, sn);
+    if (dev.get()) devices.push_back(dev);
+  }
+
+  ROS_WARN_COND(devices.empty(), "No device created.");
+  return devices;
+}
+
+}  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/device/device_factory.cc
+++ b/piksi_multi_cpp/src/device/device_factory.cc
@@ -6,21 +6,22 @@
 namespace piksi_multi_cpp {
 
 Device::DevicePtr DeviceFactory::createByDeviceTypeAndSerialNumber(
-    Device::DeviceType type, const SerialNumber& sn) {
-  if (type == Device::DeviceType::kUSB) {
+    DeviceType type, const SerialNumber& sn) {
+  if (type == DeviceType::kUSB) {
     return Device::DevicePtr(new DeviceUSB(sn));
   } else {
     return nullptr;
   }
 }
 
-std::vector<Device::DevicePtr> DeviceFactory::createAllDevicesByAutodiscovery() {
+std::vector<Device::DevicePtr>
+DeviceFactory::createAllDevicesByAutodiscovery() {
   std::vector<Device::DevicePtr> devices;
 
   // Create all USB devices.
   SerialNumbers sns = DeviceUSB::discoverAllSerialNumbers();
   for (auto sn : sns) {
-    auto dev = createByDeviceTypeAndSerialNumber(Device::DeviceType::kUSB, sn);
+    auto dev = createByDeviceTypeAndSerialNumber(DeviceType::kUSB, sn);
     if (dev.get()) devices.push_back(dev);
   }
 

--- a/piksi_multi_cpp/src/device/device_usb.cc
+++ b/piksi_multi_cpp/src/device/device_usb.cc
@@ -7,10 +7,10 @@ const int kInterfaceNumber = 1;
 
 namespace piksi_multi_cpp {
 
-DeviceUSB::DeviceUSB(const SerialNumber& sn) : Device(sn), port_(nullptr) {}
+DeviceUSB::DeviceUSB(const Identifier& id) : Device(id), port_(nullptr) {}
 
-SerialNumbers DeviceUSB::discoverAllSerialNumbers() {
-  SerialNumbers identifiers;
+Identifiers DeviceUSB::discoverAllSerialNumbers() {
+  Identifiers identifiers;
 
   // Get list of all ports.
   struct sp_port** ports;
@@ -24,10 +24,10 @@ SerialNumbers DeviceUSB::discoverAllSerialNumbers() {
   // Identify Piksi Multi among ports.
   for (int i = 0; ports[i]; i++) {
     // Check if port belongs to a Piksi Multi and get serial number.
-    SerialNumber sn = identifyPiksiAndGetSerialNumber(ports[i]);
+    Identifier id = identifyPiksiAndGetSerialNumber(ports[i]);
     // Add serial to identifier set.
-    if (!sn.empty()) {
-      identifiers.insert(sn);
+    if (!id.empty()) {
+      identifiers.insert(id);
     }
   }
 
@@ -61,7 +61,7 @@ bool DeviceUSB::allocatePort() {
 
   for (int i = 0; ports[i]; i++) {
     auto sn_query = identifyPiksiAndGetSerialNumber(ports[i]);
-    if (equalSerialNumber(sn_query, serial_number_)) {
+    if (identifierEqual(sn_query, id_)) {
       result = sp_copy_port(ports[i], &port_);
       if (result == SP_OK) {
         break;
@@ -77,8 +77,8 @@ bool DeviceUSB::allocatePort() {
     ROS_ERROR("Failed to allocate port.");
     return false;
   } else {
-    ROS_INFO_STREAM("Allocated USB port for Piksi Multi with serial number: "
-                    << serial_number_);
+    ROS_INFO_STREAM(
+        "Allocated USB port for Piksi Multi with serial number: " << id_);
     return true;
   }
 }
@@ -156,8 +156,8 @@ void DeviceUSB::close() {
   }
 }
 
-SerialNumber DeviceUSB::identifyPiksiAndGetSerialNumber(struct sp_port* port) {
-  if (!port) return SerialNumber();
+Identifier DeviceUSB::identifyPiksiAndGetSerialNumber(struct sp_port* port) {
+  if (!port) return Identifier();
 
   // Get vendor and product id to identify Piksi Multi.
   int usb_vid = -1;
@@ -175,9 +175,9 @@ SerialNumber DeviceUSB::identifyPiksiAndGetSerialNumber(struct sp_port* port) {
   if (usb_vid == kIDVendor && usb_pid == kIDProduct) {
     // Get serial number as a unique identifier.
     char* serial_number = sp_get_port_usb_serial(port);
-    return SerialNumber(serial_number);
+    return Identifier(serial_number);
   } else {
-    return SerialNumber();
+    return Identifier();
   }
 }
 

--- a/piksi_multi_cpp/src/piksi_multi_node.cc
+++ b/piksi_multi_cpp/src/piksi_multi_node.cc
@@ -1,6 +1,6 @@
 #include <ros/ros.h>
 
-#include "piksi_multi_cpp/receiver/receiver.h"
+#include "piksi_multi_cpp/receiver/receiver_factory.h"
 
 using namespace piksi_multi_cpp;
 
@@ -9,7 +9,8 @@ int main(int argc, char** argv) {
   ros::NodeHandle nh_private("~");
 
   // Autodetect all receivers.
-  auto receivers = Receiver::createAllReceivers(nh_private);
+  auto receivers =
+      ReceiverFactory::createAllReceiversByAutoDiscoveryAndNaming(nh_private);
   if (receivers.empty()) {
     ROS_FATAL("No receivers.");
     exit(1);

--- a/piksi_multi_cpp/src/receiver/receiver.cc
+++ b/piksi_multi_cpp/src/receiver/receiver.cc
@@ -10,7 +10,7 @@
 namespace piksi_multi_cpp {
 
 Receiver::Receiver(const ros::NodeHandle& nh, const Device::DevicePtr& device)
-    : nh_(nh), device_(device), thread_exit_requested_(true) {
+    : nh_(nh), device_(device), thread_exit_requested_(false) {
   // Initialize SBP state.
   state_ = std::make_shared<sbp_state_t>();
   sbp_state_init(state_.get());

--- a/piksi_multi_cpp/src/receiver/receiver.cc
+++ b/piksi_multi_cpp/src/receiver/receiver.cc
@@ -2,12 +2,6 @@
 
 #include <libsbp/sbp.h>
 #include <piksi_rtk_msgs/Heartbeat.h>
-#include "piksi_multi_cpp/device/device_factory.h"
-
-// Forward declarations
-#include "piksi_multi_cpp/receiver/receiver_attitude.h"
-#include "piksi_multi_cpp/receiver/receiver_base_station.h"
-#include "piksi_multi_cpp/receiver/receiver_position.h"
 
 // SBP message definitions.
 #include <libsbp/system.h>
@@ -18,7 +12,7 @@ std::vector<Receiver::ReceiverType> Receiver::kTypeVec =
     std::vector<Receiver::ReceiverType>(
         {kBaseStationReceiver, kPositionReceiver, kAttitudeReceiver, kUnknown});
 
-Receiver::Receiver(const ros::NodeHandle& nh, const DevicePtr& device)
+Receiver::Receiver(const ros::NodeHandle& nh, const Device::DevicePtr& device)
     : nh_(nh), device_(device), is_running_(true) {
   // Initialize SBP state.
   state_ = std::make_shared<sbp_state_t>();
@@ -26,29 +20,6 @@ Receiver::Receiver(const ros::NodeHandle& nh, const DevicePtr& device)
 
   // Register callbacks.
   cb_.push_back(SBPCallback::create(nh, SBP_MSG_HEARTBEAT, state_));
-}
-
-std::shared_ptr<Receiver> Receiver::create(const ros::NodeHandle& nh,
-                                           const DevicePtr& device,
-                                           const ReceiverType type) {
-  switch (type) {
-    case ReceiverType::kBaseStationReceiver:
-      return std::shared_ptr<Receiver>(new ReceiverBaseStation(nh, device));
-    case ReceiverType::kPositionReceiver:
-      return std::shared_ptr<Receiver>(new ReceiverPosition(nh, device));
-    case ReceiverType::kAttitudeReceiver:
-      return std::shared_ptr<Receiver>(new ReceiverAttitude(nh, device));
-    case ReceiverType::kUnknown:
-      return std::shared_ptr<Receiver>(new Receiver(nh, device));
-    default:
-      return nullptr;
-  }
-}
-
-std::shared_ptr<Receiver> Receiver::create(const ros::NodeHandle& nh,
-                                           const DevicePtr& device) {
-  ReceiverType type = inferType(device);
-  return create(nh, device, type);
 }
 
 Receiver::~Receiver() {
@@ -88,61 +59,6 @@ void Receiver::process() {
       ROS_WARN_STREAM("Error sbp_process: " << result);
     }
   }
-}
-
-std::string Receiver::createNameSpace(const ReceiverType type,
-                                      const size_t id) {
-  std::string type_name = "";
-  switch (type) {
-    case ReceiverType::kBaseStationReceiver:
-      type_name = "base_station_receiver";
-      break;
-    case ReceiverType::kPositionReceiver:
-      type_name = "position_receiver";
-      break;
-    case ReceiverType::kAttitudeReceiver:
-      type_name = "attitude_receiver";
-      break;
-    case ReceiverType::kUnknown:
-      type_name = "unknown_receiver";
-      break;
-    default:
-      type_name = "default";
-  }
-  return type_name + "_" + std::to_string(id);
-}
-
-std::vector<std::shared_ptr<Receiver>> Receiver::createAllReceivers(
-    const ros::NodeHandle& nh) {
-  // Create all devices.
-  std::vector<DevicePtr> devices =
-      DeviceFactory::createAllDevicesByAutodiscovery();
-
-  // A counter variable to assign unique ids.
-  std::map<ReceiverType, size_t> counter;
-  for (const auto type : kTypeVec) counter[type] = 0;
-
-  // Create one ROS receiver per device.
-  std::vector<std::shared_ptr<Receiver>> receivers;
-  for (auto dev : devices) {
-    ReceiverType type = inferType(dev);
-    size_t unique_id = counter[type];
-    std::string ns = createNameSpace(type, unique_id);
-    ros::NodeHandle nh_private(nh, ns);
-    auto receiver = create(nh_private, dev, type);
-    if (receiver.get()) receivers.push_back(receiver);
-    counter[type] = counter[type] + 1;
-  }
-
-  ROS_WARN_COND(receivers.empty(), "No receiver created.");
-  return receivers;
-}
-
-Receiver::ReceiverType Receiver::inferType(const DevicePtr& dev) {
-  if (!dev.get()) return ReceiverType::kUnknown;
-
-  ROS_WARN("inferType not implemented.");
-  return ReceiverType::kUnknown;
 }
 
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/receiver/receiver.cc
+++ b/piksi_multi_cpp/src/receiver/receiver.cc
@@ -9,10 +9,6 @@
 
 namespace piksi_multi_cpp {
 
-std::vector<Receiver::ReceiverType> Receiver::kTypeVec =
-    std::vector<Receiver::ReceiverType>(
-        {kBaseStationReceiver, kPositionReceiver, kAttitudeReceiver, kUnknown});
-
 Receiver::Receiver(const ros::NodeHandle& nh, const Device::DevicePtr& device)
     : nh_(nh), device_(device), is_running_(true) {
   // Initialize SBP state.

--- a/piksi_multi_cpp/src/receiver/receiver.cc
+++ b/piksi_multi_cpp/src/receiver/receiver.cc
@@ -1,6 +1,7 @@
 #include "piksi_multi_cpp/receiver/receiver.h"
 
 #include <libsbp/sbp.h>
+#include <piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_factory.h>
 #include <piksi_rtk_msgs/Heartbeat.h>
 
 // SBP message definitions.
@@ -19,7 +20,8 @@ Receiver::Receiver(const ros::NodeHandle& nh, const Device::DevicePtr& device)
   sbp_state_init(state_.get());
 
   // Register callbacks.
-  cb_.push_back(SBPCallback::create(nh, SBP_MSG_HEARTBEAT, state_));
+  cb_.push_back(SBPCallbackHandlerFactory::createSBPRelayCallbackBySBPMsgType(
+      nh, SBP_MSG_HEARTBEAT, state_));
 }
 
 Receiver::~Receiver() {

--- a/piksi_multi_cpp/src/receiver/receiver.cc
+++ b/piksi_multi_cpp/src/receiver/receiver.cc
@@ -10,7 +10,7 @@
 namespace piksi_multi_cpp {
 
 Receiver::Receiver(const ros::NodeHandle& nh, const Device::DevicePtr& device)
-    : nh_(nh), device_(device), is_running_(true) {
+    : nh_(nh), device_(device), thread_exit_requested_(true) {
   // Initialize SBP state.
   state_ = std::make_shared<sbp_state_t>();
   sbp_state_init(state_.get());

--- a/piksi_multi_cpp/src/receiver/receiver.cc
+++ b/piksi_multi_cpp/src/receiver/receiver.cc
@@ -16,7 +16,7 @@ Receiver::Receiver(const ros::NodeHandle& nh, const Device::DevicePtr& device)
   sbp_state_init(state_.get());
 
   // Register callbacks.
-  cb_.push_back(SBPCallbackHandlerFactory::createSBPRelayCallbackBySBPMsgType(
+  cb_.push_back(SBPCallbackHandlerFactory::createRelayCallbackBySBPMsgType(
       nh, SBP_MSG_HEARTBEAT, state_));
 }
 

--- a/piksi_multi_cpp/src/receiver/receiver_factory.cc
+++ b/piksi_multi_cpp/src/receiver/receiver_factory.cc
@@ -1,0 +1,92 @@
+#include <ros/console.h>
+#include "piksi_multi_cpp/device/device_factory.h"
+#include "piksi_multi_cpp/receiver/receiver.h"
+#include "piksi_multi_cpp/receiver/receiver_attitude.h"
+#include "piksi_multi_cpp/receiver/receiver_base_station.h"
+#include "piksi_multi_cpp/receiver/receiver_factory.h"
+#include "piksi_multi_cpp/receiver/receiver_position.h"
+
+namespace piksi_multi_cpp {
+
+Receiver::ReceiverPtr
+ReceiverFactory::createReceiverByNodeHandleDeviceAndReceiverType(
+    const ros::NodeHandle& nh, const Device::DevicePtr& device,
+    const Receiver::ReceiverType type) {
+  switch (type) {
+    case Receiver::ReceiverType::kBaseStationReceiver:
+      return Receiver::ReceiverPtr(new ReceiverBaseStation(nh, device));
+    case Receiver::ReceiverType::kPositionReceiver:
+      return Receiver::ReceiverPtr(new ReceiverPosition(nh, device));
+    case Receiver::ReceiverType::kAttitudeReceiver:
+      return Receiver::ReceiverPtr(new ReceiverAttitude(nh, device));
+    case Receiver::ReceiverType::kUnknown:
+      return Receiver::ReceiverPtr(new Receiver(nh, device));
+    default:
+      return nullptr;
+  }
+}
+
+Receiver::ReceiverPtr ReceiverFactory::createReceiverByNodeHandleAndDevice(
+    const ros::NodeHandle& nh, const Device::DevicePtr& device) {
+  Receiver::ReceiverType type = inferType(device);
+  return createReceiverByNodeHandleDeviceAndReceiverType(nh, device, type);
+}
+
+std::vector<Receiver::ReceiverPtr>
+ReceiverFactory::createAllReceiversByAutoDiscoveryAndNaming(
+    const ros::NodeHandle& nh) {
+  // Create all devices.
+  auto devices = DeviceFactory::createAllDevicesByAutodiscovery();
+
+  // A counter variable to assign unique ids.
+  std::map<Receiver::ReceiverType, size_t> counter;
+  for (const auto type : Receiver::kTypeVec) counter[type] = 0;
+
+  // Create one ROS receiver per device.
+  std::vector<std::shared_ptr<Receiver>> receivers;
+  for (auto dev : devices) {
+    Receiver::ReceiverType type = inferType(dev);
+    size_t unique_id = counter[type];
+    std::string ns = createNameSpace(type, unique_id);
+    ros::NodeHandle nh_private(nh, ns);
+    auto receiver =
+        createReceiverByNodeHandleDeviceAndReceiverType(nh_private, dev, type);
+    if (receiver.get()) receivers.push_back(receiver);
+    counter[type] = counter[type] + 1;
+  }
+
+  ROS_WARN_COND(receivers.empty(), "No receiver created.");
+  return receivers;
+}
+
+std::string ReceiverFactory::createNameSpace(const Receiver::ReceiverType type,
+                                             const size_t id) {
+  std::string type_name = "";
+  switch (type) {
+    case Receiver::ReceiverType::kBaseStationReceiver:
+      type_name = "base_station_receiver";
+      break;
+    case Receiver::ReceiverType::kPositionReceiver:
+      type_name = "position_receiver";
+      break;
+    case Receiver::ReceiverType::kAttitudeReceiver:
+      type_name = "attitude_receiver";
+      break;
+    case Receiver::ReceiverType::kUnknown:
+      type_name = "unknown_receiver";
+      break;
+    default:
+      type_name = "default";
+  }
+  return type_name + "_" + std::to_string(id);
+}
+
+Receiver::ReceiverType ReceiverFactory::inferType(
+    const Device::DevicePtr& dev) {
+  if (!dev.get()) return Receiver::ReceiverType::kUnknown;
+
+  ROS_WARN("inferType not implemented.");
+  return Receiver::ReceiverType::kUnknown;
+}
+
+}  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/receiver/receiver_factory.cc
+++ b/piksi_multi_cpp/src/receiver/receiver_factory.cc
@@ -8,8 +8,7 @@
 
 namespace piksi_multi_cpp {
 
-Receiver::ReceiverPtr
-ReceiverFactory::createReceiverByNodeHandleDeviceAndReceiverType(
+Receiver::ReceiverPtr ReceiverFactory::createReceiverByReceiverType(
     const ros::NodeHandle& nh, const Device::DevicePtr& device,
     const ReceiverType type) {
   switch (type) {
@@ -26,10 +25,10 @@ ReceiverFactory::createReceiverByNodeHandleDeviceAndReceiverType(
   }
 }
 
-Receiver::ReceiverPtr ReceiverFactory::createReceiverByNodeHandleAndDevice(
+Receiver::ReceiverPtr ReceiverFactory::createReceiverByDevice(
     const ros::NodeHandle& nh, const Device::DevicePtr& device) {
   ReceiverType type = inferType(device);
-  return createReceiverByNodeHandleDeviceAndReceiverType(nh, device, type);
+  return createReceiverByReceiverType(nh, device, type);
 }
 
 std::vector<Receiver::ReceiverPtr>
@@ -52,8 +51,7 @@ ReceiverFactory::createAllReceiversByAutoDiscoveryAndNaming(
 
     std::string ns = createNameSpace(type, counter[type]);
     ros::NodeHandle nh_private(nh, ns);
-    auto receiver =
-        createReceiverByNodeHandleDeviceAndReceiverType(nh_private, dev, type);
+    auto receiver = createReceiverByReceiverType(nh_private, dev, type);
     if (receiver.get()) receivers.push_back(receiver);
     // Increment type counter.
     counter[type] += 1;

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler.cc
@@ -8,8 +8,9 @@
 
 namespace piksi_multi_cpp {
 
-SBPCallback::SBPCallback(const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
-                         const std::shared_ptr<sbp_state_t>& state)
+SBPCallbackHandler::SBPCallbackHandler(
+    const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
+    const std::shared_ptr<sbp_state_t>& state)
     : nh_(nh), state_(state) {
   sbp_register_callback(
       state.get(), sbp_msg_type,
@@ -17,29 +18,16 @@ SBPCallback::SBPCallback(const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
       &sbp_msg_callback_node_);
 }
 
-void SBPCallback::callback_redirect(uint16_t sender_id, uint8_t len,
-                                    uint8_t msg[], void* context) {
+void SBPCallbackHandler::callback_redirect(uint16_t sender_id, uint8_t len,
+                                           uint8_t msg[], void* context) {
   if (!context) {
     ROS_ERROR("Context not set.");
     return;
   }
   // Cast context to instance.
-  SBPCallback* instance = static_cast<SBPCallback*>(context);
+  SBPCallbackHandler* instance = static_cast<SBPCallbackHandler*>(context);
   // Execute instance's read function.
   return instance->callback(sender_id, len, msg);
-}
-
-std::shared_ptr<SBPCallback> SBPCallback::create(
-    const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
-    const std::shared_ptr<sbp_state_t>& state) {
-  switch (sbp_msg_type) {
-    case SBP_MSG_HEARTBEAT:
-      return std::shared_ptr<SBPCallback>(
-          new SBPCallbackHeartbeat(nh, SBP_MSG_HEARTBEAT, state));
-    default:
-      ROS_ERROR("Message type %u not implemented.", sbp_msg_type);
-      return nullptr;
-  }
 }
 
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
@@ -7,7 +7,7 @@
 namespace piksi_multi_cpp {
 
 SBPCallbackHandler::SBPCallbackHandlerPtr
-SBPCallbackHandlerFactory::createSBPRelayCallbackBySBPMsgType(
+SBPCallbackHandlerFactory::createRelayCallbackBySBPMsgType(
     const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
     const std::shared_ptr<sbp_state_t>& state) {
   switch (sbp_msg_type) {

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
@@ -1,0 +1,23 @@
+#include <libsbp/system.h>
+#include <ros/console.h>
+#include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler.h"
+#include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_factory.h"
+#include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_heartbeat.h"
+
+namespace piksi_multi_cpp {
+
+SBPCallbackHandler::SBPCallbackHandlerPtr
+SBPCallbackHandlerFactory::createSBPRelayCallbackBySBPMsgType(
+    const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
+    const std::shared_ptr<sbp_state_t>& state) {
+  switch (sbp_msg_type) {
+    case SBP_MSG_HEARTBEAT:
+      return SBPCallbackHandler::SBPCallbackHandlerPtr(
+          new SBPCallbackHeartbeat(nh, SBP_MSG_HEARTBEAT, state));
+    default:
+      ROS_ERROR("Message type %u not implemented.", sbp_msg_type);
+      return nullptr;
+  }
+}
+
+}  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_heartbeat.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_heartbeat.cc
@@ -8,7 +8,7 @@ namespace piksi_multi_cpp {
 SBPCallbackHeartbeat::SBPCallbackHeartbeat(
     const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
     const std::shared_ptr<sbp_state_t>& state)
-    : SBPCallback(nh, sbp_msg_type, state) {
+    : SBPCallbackHandler(nh, sbp_msg_type, state) {
   // Advertise ROS topics.
   relay_pub_ = nh_.advertise<piksi_rtk_msgs::Heartbeat>("heartbeat", kQueueSize,
                                                         kLatchTopic);


### PR DESCRIPTION
This PR separates classes from its factory methods. This helps understanding the class interfaces and abstracts it further to the user of the classes. This is also a step towards a better interface for SBP callbacks which we discussed in https://github.com/ethz-asl/ethz_piksi_ros/pull/103.

Addresses the issue of creating circular dependencies https://github.com/ethz-asl/ethz_piksi_ros/issues/102.