### PR TITLE
Serial Port Device

### DIFF
--- a/piksi_multi_cpp/CMakeLists.txt
+++ b/piksi_multi_cpp/CMakeLists.txt
@@ -11,21 +11,22 @@ catkin_simple(ALL_DEPS_REQUIRED)
 # LIBRARIES #
 #############
 cs_add_library(${PROJECT_NAME}
-  src/device/device.cc
-  src/device/device_factory.cc
-  src/device/device_usb.cc
-  src/device/device_tcp.cc
-  src/receiver/receiver_attitude.cc
-  src/receiver/receiver_base_station.cc
-  src/receiver/receiver_factory.cc
-  src/receiver/receiver_position.cc
-  src/receiver/receiver.cc
-  src/sbp_callback_handler/sbp_callback_handler.cc
-  src/sbp_callback_handler/sbp_callback_handler_factory.cc
-  src/sbp_callback_handler/sbp_callback_handler_relay/sbp_callback_handler_relay.cc
-  src/sbp_callback_handler/sbp_callback_handler_relay/sbp_callback_handler_relay_heartbeat.cc
-  src/sbp_callback_handler/sbp_callback_handler_relay/sbp_callback_handler_relay_imu_raw.cc
-)
+        src/device/device.cc
+        src/device/device_factory.cc
+        src/device/device_usb.cc
+        src/device/device_serial.cc
+        src/device/device_tcp.cc
+        src/receiver/receiver_attitude.cc
+        src/receiver/receiver_base_station.cc
+        src/receiver/receiver_factory.cc
+        src/receiver/receiver_position.cc
+        src/receiver/receiver.cc
+        src/sbp_callback_handler/sbp_callback_handler.cc
+        src/sbp_callback_handler/sbp_callback_handler_factory.cc
+        src/sbp_callback_handler/sbp_callback_handler_relay/sbp_callback_handler_relay.cc
+        src/sbp_callback_handler/sbp_callback_handler_relay/sbp_callback_handler_relay_heartbeat.cc
+        src/sbp_callback_handler/sbp_callback_handler_relay/sbp_callback_handler_relay_imu_raw.cc
+        )
 target_link_libraries(${PROJECT_NAME} serialport)
 
 ############

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device.h
@@ -17,7 +17,7 @@ inline bool identifierEqual(const Identifier& a, const Identifier& b) {
 
 class Device {
  public:
-  enum DeviceType { kUSB = 0, kTCP };
+  enum DeviceType { kUSB = 0, kTCP , kSerial};
   typedef std::shared_ptr<Device> Ptr;
 
   Device(const Identifier& id);

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device_serial.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device_serial.h
@@ -16,10 +16,12 @@ class DeviceSerial : public Device {
 
  protected:
   virtual bool allocatePort();
+  virtual bool parseId();
+  virtual bool setBaudRate();
+  virtual bool setPortDefaults();
   struct sp_port* port_;
 
  private:
-  bool parseId();
   std::string portname_;
   uint baudrate_;
 };

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device_serial.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device_serial.h
@@ -16,7 +16,6 @@ class DeviceSerial : public Device {
 
  protected:
   virtual bool allocatePort();
-
   struct sp_port* port_;
 
  private:

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device_serial.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device_serial.h
@@ -1,0 +1,29 @@
+#ifndef PIKSI_MULTI_CPP_DEVICE_DEVICE_SERIAL_H_
+#define PIKSI_MULTI_CPP_DEVICE_DEVICE_SERIAL_H_
+
+#include <libserialport.h>
+#include "piksi_multi_cpp/device/device.h"
+
+namespace piksi_multi_cpp {
+
+class DeviceSerial : public Device {
+ public:
+  DeviceSerial(const Identifier& id);
+
+  bool open() override;
+  int32_t read(uint8_t* buff, uint32_t n) const override;
+  void close() override;
+
+ protected:
+  virtual bool allocatePort();
+
+  struct sp_port* port_;
+
+ private:
+  bool parseId();
+  std::string portname_;
+  uint baudrate_;
+};
+}  // namespace piksi_multi_cpp
+
+#endif  // PIKSI_MULTI_CPP_DEVICE_DEVICE_SERIAL_H_

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device_usb.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device_usb.h
@@ -2,27 +2,24 @@
 #define PIKSI_MULTI_CPP_DEVICE_DEVICE_USB_H_
 
 #include <libserialport.h>
+#include "device_serial.h"
 #include "piksi_multi_cpp/device/device.h"
 
 namespace piksi_multi_cpp {
 
-class DeviceUSB : public Device {
+class DeviceUSB : public DeviceSerial {
  public:
   DeviceUSB(const Identifier& id);
 
   // List all unique Piksi multi devices using the usb serial number.
   static Identifiers discoverAllSerialNumbers();
-  bool open() override;
-  int32_t read(uint8_t* buff, uint32_t n) const override;
-  void close() override;
 
  private:
   static Identifier identifyPiksiAndGetSerialNumber(struct sp_port* port);
   static void printDeviceInfo(struct sp_port* port);
   static void printPorts();
-  bool allocatePort();
+  bool allocatePort() override ;
 
-  struct sp_port* port_;
 };
 }  // namespace piksi_multi_cpp
 

--- a/piksi_multi_cpp/include/piksi_multi_cpp/device/device_usb.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/device/device_usb.h
@@ -19,6 +19,8 @@ class DeviceUSB : public DeviceSerial {
   static void printDeviceInfo(struct sp_port* port);
   static void printPorts();
   bool allocatePort() override ;
+  bool parseId() override ;
+  bool setBaudRate() override;
 
 };
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/device/device_factory.cc
+++ b/piksi_multi_cpp/src/device/device_factory.cc
@@ -34,6 +34,8 @@ std::vector<Device::Ptr> DeviceFactory::createByIdentifier(
       } else {                            // Specific USB device
         return {Device::Ptr(new DeviceUSB(protocol_address))};
       }
+    } else if (protocol == "serial") {
+      return {Device::Ptr(new DeviceSerial(protocol_address))};
     } else if (protocol == "tcp") {  // Specific TCP device
       return {Device::Ptr(new DeviceTCP(protocol_address))};
     } else {

--- a/piksi_multi_cpp/src/device/device_serial.cc
+++ b/piksi_multi_cpp/src/device/device_serial.cc
@@ -120,7 +120,7 @@ int32_t DeviceSerial::read(uint8_t* buff, uint32_t n) const {
     return 0;
   }
 
-  return sp_blocking_read(port_, buff, n, 0);
+  return sp_blocking_read(port_, buff, n, 10000);
 }
 
 void DeviceSerial::close() {

--- a/piksi_multi_cpp/src/device/device_usb.cc
+++ b/piksi_multi_cpp/src/device/device_usb.cc
@@ -61,7 +61,6 @@ void DeviceUSB::printPorts() {
 }
 
 bool DeviceUSB::allocatePort() {
-  std::cout << "allocate USB" << std::endl;
   // Find any serial port with serial number.
   struct sp_port** ports;
   sp_return result = sp_list_ports(&ports);

--- a/piksi_multi_cpp/src/device/device_usb.cc
+++ b/piksi_multi_cpp/src/device/device_usb.cc
@@ -7,7 +7,7 @@ const int kInterfaceNumber = 1;
 
 namespace piksi_multi_cpp {
 
-DeviceUSB::DeviceUSB(const Identifier& id) : Device(id), port_(nullptr) {}
+DeviceUSB::DeviceUSB(const Identifier& id) : DeviceSerial(id) {}
 
 Identifiers DeviceUSB::discoverAllSerialNumbers() {
   Identifiers identifiers;
@@ -80,79 +80,6 @@ bool DeviceUSB::allocatePort() {
     ROS_INFO_STREAM(
         "Allocated USB port for Piksi Multi with serial number: " << id_);
     return true;
-  }
-}
-
-bool DeviceUSB::open() {
-  // Allocate port.
-  if (!allocatePort()) {
-    close();
-    return false;
-  }
-
-  // Open port.
-  sp_return result = sp_open(port_, SP_MODE_READ);
-  if (result != SP_OK) {
-    ROS_ERROR("Cannot open port %s: %d", sp_get_port_name(port_), result);
-    close();
-    return false;
-  }
-  ROS_INFO_STREAM("Opened port: " << sp_get_port_name(port_));
-
-  // Configuration.
-  // https://github.com/swift-nav/libsbp/blob/master/c/example/example.c
-  result = sp_set_flowcontrol(port_, SP_FLOWCONTROL_NONE);
-  if (result != SP_OK) {
-    ROS_ERROR_STREAM("Cannot set flow control: " << result);
-    close();
-    return false;
-  }
-  ROS_DEBUG("Configured the flow control.");
-
-  result = sp_set_bits(port_, 8);
-  if (result != SP_OK) {
-    ROS_ERROR_STREAM("Cannot set data bits: " << result);
-    close();
-    return false;
-  }
-  ROS_DEBUG("Configured the number of data bits.");
-
-  result = sp_set_parity(port_, SP_PARITY_NONE);
-  if (result != SP_OK) {
-    ROS_ERROR_STREAM("Cannot set parity: " << result);
-    close();
-    return false;
-  }
-  ROS_DEBUG("Configured the parity.");
-
-  result = sp_set_stopbits(port_, 1);
-  if (result != SP_OK) {
-    ROS_ERROR_STREAM("Cannot set stop bits: " << result);
-    close();
-    return false;
-  }
-  ROS_DEBUG("Configured the number of stop bits.");
-
-  return true;
-}
-
-int32_t DeviceUSB::read(uint8_t* buff, uint32_t n) const {
-  if (!port_) {
-    ROS_ERROR_STREAM("Port not opened.");
-    return 0;
-  }
-
-  return sp_blocking_read(port_, buff, n, 0);
-}
-
-void DeviceUSB::close() {
-  if (port_) {
-    sp_return result = sp_close(port_);
-    if (result != SP_OK) {
-      ROS_ERROR("Cannot close %s properly.", sp_get_port_name(port_));
-    }
-    sp_free_port(port_);
-    port_ = nullptr;
   }
 }
 

--- a/piksi_multi_cpp/src/device/device_usb.cc
+++ b/piksi_multi_cpp/src/device/device_usb.cc
@@ -9,6 +9,16 @@ namespace piksi_multi_cpp {
 
 DeviceUSB::DeviceUSB(const Identifier& id) : DeviceSerial(id) {}
 
+bool DeviceUSB::parseId() {
+  // not much to check with USB ids.
+  return true;
+}
+
+bool DeviceUSB::setBaudRate() {
+  // not necessary.
+  return true;
+}
+
 Identifiers DeviceUSB::discoverAllSerialNumbers() {
   Identifiers identifiers;
 
@@ -51,6 +61,7 @@ void DeviceUSB::printPorts() {
 }
 
 bool DeviceUSB::allocatePort() {
+  std::cout << "allocate USB" << std::endl;
   // Find any serial port with serial number.
   struct sp_port** ports;
   sp_return result = sp_list_ports(&ports);


### PR DESCRIPTION
- Factored the Serial port stuff of the DeviceUSB into DeviceSerial 
- DeviceUSB is inherited from DeviceSerial, but overwrite the allocatePort method and adds the nice autodiscovery stuff

- Connection string for a serial device is `serial://<device>@<baudrate>`. Example: `serial:///dev/ttyUSB0@921600` . Note the resulting triple slash.

Not tested yet, will update PR once ready.