### PR TITLE
Feature/enu frame

### DIFF
--- a/piksi_multi_cpp/CMakeLists.txt
+++ b/piksi_multi_cpp/CMakeLists.txt
@@ -33,6 +33,7 @@ cs_add_library(${PROJECT_NAME}
         src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
         src/sbp_callback_handler/sbp_callback_handler_relay/ros_mag_relay.cc
         src/sbp_callback_handler/sbp_callback_handler_relay/ros_receiver_state.cc
+        src/sbp_callback_handler/geotf_handler.cc
         src/sbp_callback_handler/position_sampler.cc
         src/sbp_callback_handler/ros_time_handler.cc
         src/sbp_callback_handler/sbp_callback_handler.cc

--- a/piksi_multi_cpp/CMakeLists.txt
+++ b/piksi_multi_cpp/CMakeLists.txt
@@ -30,6 +30,7 @@ cs_add_library(${PROJECT_NAME}
         src/receiver/settings_io.cc
         src/sbp_callback_handler/sbp_callback_handler_relay/ros_relays.cc
         src/sbp_callback_handler/sbp_callback_handler_relay/ros_imu_relay.cc
+        src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
         src/sbp_callback_handler/sbp_callback_handler_relay/ros_mag_relay.cc
         src/sbp_callback_handler/sbp_callback_handler_relay/ros_receiver_state.cc
         src/sbp_callback_handler/position_sampler.cc

--- a/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_ros.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_ros.h
@@ -7,6 +7,7 @@
 #include <thread>
 #include <vector>
 #include "piksi_multi_cpp/receiver/settings_io.h"
+#include "piksi_multi_cpp/sbp_callback_handler/geotf_handler.h"
 #include "piksi_multi_cpp/sbp_callback_handler/position_sampler.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_observation_callback_handler.h"
@@ -33,6 +34,8 @@ class ReceiverRos : public SettingsIo {
 
   // Averages the position over multiple ECEF messages.
   PositionSampler::Ptr position_sampler_;
+  // Manages geotf transformations.
+  GeoTfHandler::Ptr geotf_handler_;
 
  private:
   // Relaying all SBP messages. Common for all receivers.

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
@@ -26,10 +26,13 @@ class GeoTfHandler {
 
  private:
   void callbackToPosLlh(const msg_pos_llh_t& msg, const uint8_t len);
+  void callbackToBasePosLlh(const msg_base_pos_llh_t& msg, const uint8_t len);
 
   bool use_base_enu_origin_ = true;  // False: ENU origin is first position.
   SBPLambdaCallbackHandler<msg_pos_llh_t> pos_llh_handler_;
+  SBPLambdaCallbackHandler<msg_base_pos_llh_t> base_pos_llh_handler_;
   geotf::GeodeticConverter geotf_;
+  Eigen::Vector3d enu_origin_wgs84_;
 };
 
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
@@ -25,6 +25,8 @@ class GeoTfHandler {
   bool convertPosEcefToEnu(const Eigen::Vector3d& pos_ecef,
                            const Eigen::Vector3d* pos_enu);
 
+  inline geotf::GeodeticConverter getGeoTf() const {return geotf_;}
+
   GeoTfHandler(GeoTfHandler const&) = delete;
   void operator=(GeoTfHandler const&) = delete;
 

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
@@ -4,6 +4,7 @@
 #include <geotf/geodetic_converter.h>
 #include <libsbp/navigation.h>
 #include <piksi_rtk_msgs/EnuOrigin.h>
+#include <ros/ros.h>
 #include <std_srvs/Empty.h>
 #include <Eigen/Dense>
 #include <memory>
@@ -17,7 +18,8 @@ namespace piksi_multi_cpp {
 class GeoTfHandler {
  public:
   typedef std::shared_ptr<GeoTfHandler> Ptr;
-  GeoTfHandler(const std::shared_ptr<sbp_state_t>& state);
+  GeoTfHandler(const ros::NodeHandle& nh,
+               const std::shared_ptr<sbp_state_t>& state);
 
   void setEnuOriginWgs84(const double lat, const double lon, const double alt);
   void resetEnuOrigin();
@@ -25,7 +27,7 @@ class GeoTfHandler {
   bool convertPosEcefToEnu(const Eigen::Vector3d& pos_ecef,
                            const Eigen::Vector3d* pos_enu);
 
-  inline geotf::GeodeticConverter getGeoTf() const {return geotf_;}
+  inline geotf::GeodeticConverter getGeoTf() const { return geotf_; }
 
   GeoTfHandler(GeoTfHandler const&) = delete;
   void operator=(GeoTfHandler const&) = delete;
@@ -41,6 +43,7 @@ class GeoTfHandler {
   geotf::GeodeticConverter geotf_;
   Eigen::Vector3d enu_origin_wgs84_;
 
+  ros::NodeHandle nh_;
   ros::ServiceServer set_enu_origin_srv_;
   ros::ServiceServer reset_enu_origin_srv_;
 };

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
@@ -1,0 +1,37 @@
+#ifndef PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_GEOTF_HANDLER_H_
+#define PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_GEOTF_HANDLER_H_
+
+#include <geotf/geodetic_converter.h>
+#include <libsbp/navigation.h>
+#include <Eigen/Dense>
+#include <memory>
+#include "piksi_multi_cpp/sbp_callback_handler/sbp_lambda_callback_handler.h"
+
+namespace piksi_multi_cpp {
+
+// Manages a geotf object to transform between frames.
+class GeoTfHandler {
+ public:
+  typedef std::shared_ptr<GeoTfHandler> Ptr;
+  GeoTfHandler(const std::shared_ptr<sbp_state_t>& state);
+
+  void setEnuOriginWgs84(const double lat, const double lon, const double alt);
+  void resetEnuOrigin();
+
+  bool convertPosEcefToEnu(const Eigen::Vector3d& pos_ecef,
+                           const Eigen::Vector3d* pos_enu);
+
+  GeoTfHandler(GeoTfHandler const&) = delete;
+  void operator=(GeoTfHandler const&) = delete;
+
+ private:
+  void callbackToPosLlh(const msg_pos_llh_t& msg, const uint8_t len);
+
+  bool use_base_enu_origin_ = true;  // False: ENU origin is first position.
+  SBPLambdaCallbackHandler<msg_pos_llh_t> pos_llh_handler_;
+  geotf::GeodeticConverter geotf_;
+};
+
+}  // namespace piksi_multi_cpp
+
+#endif  // PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_GEOTF_HANDLER_H_

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
@@ -3,6 +3,8 @@
 
 #include <geotf/geodetic_converter.h>
 #include <libsbp/navigation.h>
+#include <piksi_rtk_msgs/EnuOrigin.h>
+#include <std_srvs/Empty.h>
 #include <Eigen/Dense>
 #include <memory>
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_lambda_callback_handler.h"
@@ -10,6 +12,8 @@
 namespace piksi_multi_cpp {
 
 // Manages a geotf object to transform between frames.
+// The ENU frame is either set automatically to be the base station position,
+// through ROS parameters or reset through a service call.
 class GeoTfHandler {
  public:
   typedef std::shared_ptr<GeoTfHandler> Ptr;
@@ -25,14 +29,18 @@ class GeoTfHandler {
   void operator=(GeoTfHandler const&) = delete;
 
  private:
-  void callbackToPosLlh(const msg_pos_llh_t& msg, const uint8_t len);
   void callbackToBasePosLlh(const msg_base_pos_llh_t& msg, const uint8_t len);
+  bool setEnuOriginCallback(piksi_rtk_msgs::EnuOrigin::Request& req,
+                            piksi_rtk_msgs::EnuOrigin::Response& res);
+  bool resetEnuOriginCallback(std_srvs::Empty::Request& req,
+                              std_srvs::Empty::Response& res);
 
-  bool use_base_enu_origin_ = true;  // False: ENU origin is first position.
-  SBPLambdaCallbackHandler<msg_pos_llh_t> pos_llh_handler_;
   SBPLambdaCallbackHandler<msg_base_pos_llh_t> base_pos_llh_handler_;
   geotf::GeodeticConverter geotf_;
   Eigen::Vector3d enu_origin_wgs84_;
+
+  ros::ServiceServer set_enu_origin_srv_;
+  ros::ServiceServer reset_enu_origin_srv_;
 };
 
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
@@ -22,7 +22,6 @@ class GeoTfHandler {
                const std::shared_ptr<sbp_state_t>& state);
 
   void setEnuOriginWgs84(const double lat, const double lon, const double alt);
-  void resetEnuOrigin();
 
   bool convertPosEcefToEnu(const Eigen::Vector3d& pos_ecef,
                            const Eigen::Vector3d* pos_enu);
@@ -34,18 +33,26 @@ class GeoTfHandler {
 
  private:
   void callbackToBasePosLlh(const msg_base_pos_llh_t& msg, const uint8_t len);
+  void callbackToPosLlh(const msg_pos_llh_t& msg, const uint8_t len);
   bool setEnuOriginCallback(piksi_rtk_msgs::EnuOrigin::Request& req,
                             piksi_rtk_msgs::EnuOrigin::Response& res);
-  bool resetEnuOriginCallback(std_srvs::Empty::Request& req,
-                              std_srvs::Empty::Response& res);
+  bool setEnuOriginFromBaseStation(std_srvs::Empty::Request& req,
+                                   std_srvs::Empty::Response& res);
+  bool setEnuOriginFromCurrentPos(std_srvs::Empty::Request& req,
+                                  std_srvs::Empty::Response& res);
 
   SBPLambdaCallbackHandler<msg_base_pos_llh_t> base_pos_llh_handler_;
+  SBPLambdaCallbackHandler<msg_pos_llh_t> pos_llh_handler_;
   geotf::GeodeticConverter geotf_;
   Eigen::Vector3d enu_origin_wgs84_;
 
   ros::NodeHandle nh_;
   ros::ServiceServer set_enu_origin_srv_;
-  ros::ServiceServer reset_enu_origin_srv_;
+  ros::ServiceServer set_enu_from_base_srv_;
+  ros::ServiceServer set_enu_from_current_srv_;
+
+  enum ResetEnuOrigin {kNo = 0, kFromBase, kFromCurrentPos};
+  ResetEnuOrigin reset_position_ = ResetEnuOrigin::kFromCurrentPos;
 };
 
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_factory.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_factory.h
@@ -4,6 +4,7 @@
 #include <libsbp/sbp.h>
 #include <memory>
 #include <vector>
+#include "piksi_multi_cpp/sbp_callback_handler/geotf_handler.h"
 #include "piksi_multi_cpp/sbp_callback_handler/ros_time_handler.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler.h"
 
@@ -21,7 +22,8 @@ class SBPCallbackHandlerFactory {
 
   static std::vector<SBPCallbackHandler::Ptr> createAllRosMessageRelays(
       const ros::NodeHandle& nh, const std::shared_ptr<sbp_state_t>& state,
-      const RosTimeHandler::Ptr& ros_time_handler);
+      const RosTimeHandler::Ptr& ros_time_handler,
+      const GeoTfHandler::Ptr& geotf_handler);
 };
 }  // namespace piksi_multi_cpp
 

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
@@ -24,19 +24,21 @@ class RosEnuRelay : public RosRelay<SbpMsgType, RosMsgType> {
                                          ros_time_handler, "enu") {
     geotf_.addFrameByEPSG("ecef", 4978);
     geotf_.addFrameByEPSG("wgs84", 4326);
+    ros::NodeHandle nh_node("~");
+    nh_node.param<bool>("use_base_enu_origin", use_base_enu_origin_,
+                        use_base_enu_origin_);
   }
 
  public:
-  inline void setEnuOrigin(const double lat, const double lon,
-                           const double alt) {
-    enu_origin_wgs84_ = Eigen::Vector3d(lat, lon, alt);
+  inline void setEnuOriginWgs84(const double lat, const double lon,
+                                const double alt) {
+    geotf_.addFrameByENUOrigin("enu", lat, lon, alt);
   }
 
-  inline void resetEnuOrigin() { enu_origin_wgs84_.reset(); }
+  inline void resetEnuOrigin() { geotf_.removeFrame("enu"); }
 
  protected:
   bool use_base_enu_origin_ = true;  // False: ENU origin is first position.
-  std::optional<Eigen::Vector3d> enu_origin_wgs84_;
   geotf::GeodeticConverter geotf_;
 
  private:

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
@@ -1,13 +1,17 @@
 #ifndef PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_ENU_RELAYS_H_
 #define PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_ENU_RELAYS_H_
 
-#include <geometry_msgs/PointStamped.h>
 #include <geotf/geodetic_converter.h>
 #include <libsbp/navigation.h>
-#include <piksi_rtk_msgs/PositionWithCovarianceStamped.h>
 #include <ros/assert.h>
 #include <Eigen/Dense>
 #include <optional>
+
+#include <geometry_msgs/PointStamped.h>
+#include <piksi_rtk_msgs/PositionWithCovarianceStamped.h>
+
+#include "piksi_multi_cpp/sbp_callback_handler/geotf_handler.h"
+#include "piksi_multi_cpp/sbp_callback_handler/ros_time_handler.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_relay.h"
 
 namespace piksi_multi_cpp {
@@ -20,60 +24,14 @@ class RosEnuRelay : public RosRelay<SbpMsgType, RosMsgType> {
   inline RosEnuRelay(const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
                      const std::shared_ptr<sbp_state_t>& state,
                      const std::string& topic,
-                     const RosTimeHandler::Ptr& ros_time_handler)
+                     const RosTimeHandler::Ptr& ros_time_handler,
+                     const GeoTfHandler::Ptr& geotf_handler)
       : RosRelay<SbpMsgType, RosMsgType>(nh, sbp_msg_type, state, topic,
-                                         ros_time_handler, "enu") {
-    geotf_.addFrameByEPSG("ecef", 4978);
-    geotf_.addFrameByEPSG("wgs84", 4326);
-    ros::NodeHandle nh_node("~");
-    nh_node.param<bool>("use_base_enu_origin", use_base_enu_origin_,
-                        use_base_enu_origin_);
-  }
-
- public:
-  inline void setEnuOriginWgs84(const double lat, const double lon,
-                                const double alt) {
-    geotf_.addFrameByENUOrigin("enu", lat, lon, alt);
-  }
-
-  inline void resetEnuOrigin() { geotf_.removeFrame("enu"); }
+                                         ros_time_handler, "enu"),
+        geotf_handler_(geotf_handler) {}
 
  protected:
-  // Updates ENU origin if it is not to be set from base station position.
-  inline void updateEnuOriginFromEcef(const Eigen::Vector3d& x_ecef) {
-    if (use_base_enu_origin_)
-      return;  // Wait for base station position instead.
-    if (geotf_.hasFrame("enu")) return;  // Already set.
-
-    Eigen::Vector3d x_wgs84;
-    if (!geotf_.convert("ecef", x_ecef, "wgs84", &x_wgs84)) {
-      ROS_ERROR("Failed to convert ECEF to WGS84.");
-      return;
-    }
-
-    geotf_.addFrameByENUOrigin("enu", x_wgs84.x(), x_wgs84.y(), x_wgs84.z());
-  }
-
-  inline void convertPositionEcefToEnu(const Eigen::Vector3d& x_ecef,
-                                       Eigen::Vector3d* x_enu) {
-    ROS_ASSERT(x_enu);
-
-    if (!geotf_.canConvert("ecef", "enu")) {
-      ROS_WARN_THROTTLE(
-          5.0, "Cannot convert ECEF to ENU. Waiting for ENU to be set.");
-      return;
-    }
-
-    if (!geotf_.convert("ecef", x_ecef, "enu", x_enu)) {
-      ROS_ERROR("Failed to convert ECEF to ENU.");
-      return;
-    }
-  }
-
-  bool use_base_enu_origin_ = true;  // False: ENU origin is first position.
-  geotf::GeodeticConverter geotf_;
-
- private:
+  GeoTfHandler::Ptr geotf_handler_;
 };
 
 class RosPosEnuRelay
@@ -81,11 +39,13 @@ class RosPosEnuRelay
  public:
   inline RosPosEnuRelay(const ros::NodeHandle& nh,
                         const std::shared_ptr<sbp_state_t>& state,
-                        const RosTimeHandler::Ptr& ros_time_handler)
-      : RosEnuRelay(nh, SBP_MSG_POS_ECEF, state, "pos_enu", ros_time_handler) {}
+                        const RosTimeHandler::Ptr& ros_time_handler,
+                        const GeoTfHandler::Ptr& geotf_handler)
+      : RosEnuRelay(nh, SBP_MSG_POS_ECEF, state, "pos_enu", ros_time_handler,
+                    geotf_handler) {}
 
  private:
-  void convertSbpMsgToRosMsg(const msg_pos_ecef_t& in, const uint8_t len,
+  bool convertSbpMsgToRosMsg(const msg_pos_ecef_t& in, const uint8_t len,
                              geometry_msgs::PointStamped* out) override;
 };
 

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
@@ -1,23 +1,58 @@
 #ifndef PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_ENU_RELAYS_H_
 #define PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_ENU_RELAYS_H_
 
+#include <geometry_msgs/PointStamped.h>
+#include <geotf/geodetic_converter.h>
 #include <libsbp/navigation.h>
 #include <piksi_rtk_msgs/PositionWithCovarianceStamped.h>
+#include <Eigen/Dense>
+#include <optional>
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_relay.h"
 
 namespace piksi_multi_cpp {
 
+// Per default the ENU origin will be the base station position. But it can also
+// be set to the current rover position or a user defined position.
+template <class SbpMsgType, class RosMsgType>
+class RosEnuRelay : public RosRelay<SbpMsgType, RosMsgType> {
+ public:
+  inline RosEnuRelay(const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
+                     const std::shared_ptr<sbp_state_t>& state,
+                     const std::string& topic,
+                     const RosTimeHandler::Ptr& ros_time_handler)
+      : RosRelay<SbpMsgType, RosMsgType>(nh, sbp_msg_type, state, topic,
+                                         ros_time_handler, "enu") {
+    geotf_.addFrameByEPSG("ecef", 4978);
+    geotf_.addFrameByEPSG("wgs84", 4326);
+  }
+
+ public:
+  inline void setEnuOrigin(const double lat, const double lon,
+                           const double alt) {
+    enu_origin_wgs84_ = Eigen::Vector3d(lat, lon, alt);
+  }
+
+  inline void resetEnuOrigin() { enu_origin_wgs84_.reset(); }
+
+ protected:
+  bool use_base_enu_origin_ = true;  // False: ENU origin is first position.
+  std::optional<Eigen::Vector3d> enu_origin_wgs84_;
+  geotf::GeodeticConverter geotf_;
+
+ private:
+};
+
 class RosPosEnuRelay
-    : public RosRelay<msg_pos_ecef_cov_t,
-                      piksi_rtk_msgs::PositionWithCovarianceStamped> {
+    : public RosEnuRelay<msg_pos_ecef_t, geometry_msgs::PointStamped> {
  public:
   inline RosPosEnuRelay(const ros::NodeHandle& nh,
                         const std::shared_ptr<sbp_state_t>& state,
                         const RosTimeHandler::Ptr& ros_time_handler)
-      : RosRelay(nh, SBP_MSG_POS_ECEF, state, "pos_enu", ros_time_handler,
-                 "enu") {}
+      : RosEnuRelay(nh, SBP_MSG_POS_ECEF, state, "pos_enu", ros_time_handler) {}
 
  private:
+  void convertSbpMsgToRosMsg(const msg_pos_ecef_t& in, const uint8_t len,
+                             geometry_msgs::PointStamped* out) override;
 };
 
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
@@ -1,0 +1,25 @@
+#ifndef PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_ENU_RELAYS_H_
+#define PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_ENU_RELAYS_H_
+
+#include <libsbp/navigation.h>
+#include <piksi_rtk_msgs/PositionWithCovarianceStamped.h>
+#include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_relay.h"
+
+namespace piksi_multi_cpp {
+
+class RosPosEnuRelay
+    : public RosRelay<msg_pos_ecef_cov_t,
+                      piksi_rtk_msgs::PositionWithCovarianceStamped> {
+ public:
+  inline RosPosEnuRelay(const ros::NodeHandle& nh,
+                        const std::shared_ptr<sbp_state_t>& state,
+                        const RosTimeHandler::Ptr& ros_time_handler)
+      : RosRelay(nh, SBP_MSG_POS_ECEF, state, "pos_enu", ros_time_handler,
+                 "enu") {}
+
+ private:
+};
+
+}  // namespace piksi_multi_cpp
+
+#endif  // PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_ENU_RELAYS_H_

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_relay.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_relay.h
@@ -24,7 +24,7 @@ class RosRelay : public SBPCallbackHandlerRelay<SbpMsgType, RosMsgType> {
 
  private:
   // Implement this method to convert the message to the desired output type.
-  virtual void convertSbpMsgToRosMsg(const SbpMsgType& sbp_msg,
+  virtual bool convertSbpMsgToRosMsg(const SbpMsgType& sbp_msg,
                                      const uint8_t len,
                                      RosMsgType* ros_msg) = 0;
 
@@ -44,7 +44,7 @@ class RosRelay : public SBPCallbackHandlerRelay<SbpMsgType, RosMsgType> {
     ros_msg->header.frame_id = frame_id_;
 
     // Manual conversion.
-    convertSbpMsgToRosMsg(sbp_msg, len, ros_msg);
+    if(!convertSbpMsgToRosMsg(sbp_msg, len, ros_msg)) return false;
     return true;
   }
 

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_relays.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_relays.h
@@ -32,7 +32,7 @@ class RosPosEcefRelay
                  "ecef") {}
 
  private:
-  void convertSbpMsgToRosMsg(const msg_pos_ecef_t& in, const uint8_t len,
+  bool convertSbpMsgToRosMsg(const msg_pos_ecef_t& in, const uint8_t len,
                              geometry_msgs::PointStamped* out) override;
 };
 
@@ -47,7 +47,7 @@ class RosPosEcefCovRelay
                  ros_time_handler, "ecef") {}
 
  private:
-  void convertSbpMsgToRosMsg(
+  bool convertSbpMsgToRosMsg(
       const msg_pos_ecef_cov_t& in, const uint8_t len,
       piksi_rtk_msgs::PositionWithCovarianceStamped* out) override;
 };
@@ -64,7 +64,7 @@ class RosPosLlhCovRelay
         ros_receiver_state_(ros_receiver_state) {}
 
  private:
-  void convertSbpMsgToRosMsg(const msg_pos_llh_cov_t& in, const uint8_t len,
+  bool convertSbpMsgToRosMsg(const msg_pos_llh_cov_t& in, const uint8_t len,
                              sensor_msgs::NavSatFix* out) override;
   RosReceiverState::Ptr ros_receiver_state_;
 };
@@ -80,7 +80,7 @@ class RosBaselineNedRelay
                  ros_time_handler, "ned_base_station") {}
 
  private:
-  void convertSbpMsgToRosMsg(
+  bool convertSbpMsgToRosMsg(
       const msg_baseline_ned_t& in, const uint8_t len,
       piksi_rtk_msgs::PositionWithCovarianceStamped* out) override;
 };
@@ -95,7 +95,7 @@ class RosVelEcefRelay
                  "ecef") {}
 
  private:
-  void convertSbpMsgToRosMsg(const msg_vel_ecef_t& in, const uint8_t len,
+  bool convertSbpMsgToRosMsg(const msg_vel_ecef_t& in, const uint8_t len,
                              geometry_msgs::Vector3Stamped* out) override;
 };
 
@@ -110,7 +110,7 @@ class RosVelEcefCovRelay
                  ros_time_handler, "ecef") {}
 
  private:
-  void convertSbpMsgToRosMsg(
+  bool convertSbpMsgToRosMsg(
       const msg_vel_ecef_cov_t& in, const uint8_t len,
       piksi_rtk_msgs::VelocityWithCovarianceStamped* out) override;
 };
@@ -125,7 +125,7 @@ class RosVelNedRelay
                  "ned") {}
 
  private:
-  void convertSbpMsgToRosMsg(const msg_vel_ned_t& in, const uint8_t len,
+  bool convertSbpMsgToRosMsg(const msg_vel_ned_t& in, const uint8_t len,
                              geometry_msgs::Vector3Stamped* out) override;
 };
 
@@ -140,7 +140,7 @@ class RosVelNedCovRelay
                  ros_time_handler, "ned") {}
 
  private:
-  void convertSbpMsgToRosMsg(
+  bool convertSbpMsgToRosMsg(
       const msg_vel_ned_cov_t& in, const uint8_t len,
       piksi_rtk_msgs::VelocityWithCovarianceStamped* out) override;
 };

--- a/piksi_multi_cpp/src/receiver/receiver_ros.cc
+++ b/piksi_multi_cpp/src/receiver/receiver_ros.cc
@@ -16,13 +16,13 @@ ReceiverRos::ReceiverRos(const ros::NodeHandle& nh, const Device::Ptr& device)
   // Register all relay callbacks.
   // Handle (GPS) time stamping.
   auto ros_time_handler = std::make_shared<RosTimeHandler>(state_);
+  geotf_handler_ = std::make_shared<GeoTfHandler>(nh, state_);
   sbp_relays_ =
       SBPCallbackHandlerFactory::createAllSBPMessageRelays(nh, state_);
   ros_relays_ = SBPCallbackHandlerFactory::createAllRosMessageRelays(
-      nh, state_, ros_time_handler);
+      nh, state_, ros_time_handler, geotf_handler_);
   position_sampler_ =
       std::make_shared<PositionSampler>(nh, state_, ros_time_handler);
-  geotf_handler_ = std::make_shared<GeoTfHandler>(state_);
 
   // Create observation callbacks
   obs_cbs_ = std::make_unique<SBPObservationCallbackHandler>(nh, state_);

--- a/piksi_multi_cpp/src/receiver/receiver_ros.cc
+++ b/piksi_multi_cpp/src/receiver/receiver_ros.cc
@@ -22,6 +22,7 @@ ReceiverRos::ReceiverRos(const ros::NodeHandle& nh, const Device::Ptr& device)
       nh, state_, ros_time_handler);
   position_sampler_ =
       std::make_shared<PositionSampler>(nh, state_, ros_time_handler);
+  geotf_handler_ = std::make_shared<GeoTfHandler>(state_);
 
   // Create observation callbacks
   obs_cbs_ = std::make_unique<SBPObservationCallbackHandler>(nh, state_);

--- a/piksi_multi_cpp/src/receiver/settings_io.cc
+++ b/piksi_multi_cpp/src/receiver/settings_io.cc
@@ -83,6 +83,17 @@ bool SettingsIo::writeSetting(const std::string& section,
     return false;
   }
 
+  // Save to persistent memory.
+  char empty_req[0];
+  int save_success =
+      sbp_send_message(state_.get(), SBP_MSG_SETTINGS_SAVE, SBP_SENDER_ID, 0,
+                       (unsigned char*)(&empty_req), &Device::write_redirect);
+  if (save_success != SBP_OK) {
+    ROS_ERROR("Cannot save setting %s.%s.%s, %d", section.c_str(), name.c_str(),
+              value.c_str(), req_success);
+    return false;
+  }
+
   // The writing sometimes fails with unspecified error. We wait a little.
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
 

--- a/piksi_multi_cpp/src/sbp_callback_handler/geotf_handler.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/geotf_handler.cc
@@ -45,6 +45,7 @@ void GeoTfHandler::callbackToBasePosLlh(const msg_base_pos_llh_t& msg,
 void GeoTfHandler::callbackToPosLlh(const msg_pos_llh_t& msg,
                                     const uint8_t len) {
   if (reset_position_ != ResetEnuOrigin::kFromCurrentPos) return;
+  if (((msg.flags >> 0) & 0x7) == 0) return;  // Fix invalid.
   setEnuOriginWgs84(msg.lat, msg.lon, msg.height);
 }
 

--- a/piksi_multi_cpp/src/sbp_callback_handler/geotf_handler.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/geotf_handler.cc
@@ -5,18 +5,19 @@
 namespace piksi_multi_cpp {
 namespace s = std::placeholders;
 
-GeoTfHandler::GeoTfHandler(const std::shared_ptr<sbp_state_t>& state)
-    : base_pos_llh_handler_{
-          std::bind(&GeoTfHandler::callbackToBasePosLlh, this, s::_1, s::_2),
-          SBP_MSG_BASE_POS_LLH, state} {
+GeoTfHandler::GeoTfHandler(const ros::NodeHandle& nh,
+                           const std::shared_ptr<sbp_state_t>& state)
+    : base_pos_llh_handler_{std::bind(&GeoTfHandler::callbackToBasePosLlh, this,
+                                      s::_1, s::_2),
+                            SBP_MSG_BASE_POS_LLH, state},
+      nh_(nh) {
   geotf_.initFromRosParam();
   geotf_.addFrameByEPSG("ecef", 4978);
   geotf_.addFrameByEPSG("wgs84", 4326);
 
-  ros::NodeHandle nh_node("~");
-  set_enu_origin_srv_ = nh_node.advertiseService(
+  set_enu_origin_srv_ = nh_.advertiseService(
       "set_enu_origin", &GeoTfHandler::setEnuOriginCallback, this);
-  reset_enu_origin_srv_ = nh_node.advertiseService(
+  reset_enu_origin_srv_ = nh_.advertiseService(
       "reset_enu_origin", &GeoTfHandler::resetEnuOriginCallback, this);
 }
 

--- a/piksi_multi_cpp/src/sbp_callback_handler/geotf_handler.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/geotf_handler.cc
@@ -2,11 +2,8 @@
 
 #include <functional>
 
-#include <libsbp_ros_msgs/ros_conversion.h>
-
 namespace piksi_multi_cpp {
 namespace s = std::placeholders;
-namespace lrm = libsbp_ros_msgs;
 
 GeoTfHandler::GeoTfHandler(const std::shared_ptr<sbp_state_t>& state)
     : base_pos_llh_handler_{
@@ -34,9 +31,7 @@ void GeoTfHandler::resetEnuOrigin() { geotf_.removeFrame("enu"); }
 void GeoTfHandler::callbackToBasePosLlh(const msg_base_pos_llh_t& msg,
                                         const uint8_t len) {
   if (geotf_.hasFrame("enu")) return;  // ENU origin already set.
-  Eigen::Vector3d x_wgs84;
-  lrm::convertWgs84Point<msg_base_pos_llh_t>(msg, &x_wgs84);
-  geotf_.addFrameByENUOrigin("enu", x_wgs84.x(), x_wgs84.y(), x_wgs84.z());
+  geotf_.addFrameByENUOrigin("enu", msg.lat, msg.lon, msg.height);
 }
 
 bool GeoTfHandler::setEnuOriginCallback(

--- a/piksi_multi_cpp/src/sbp_callback_handler/geotf_handler.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/geotf_handler.cc
@@ -9,18 +9,18 @@ namespace s = std::placeholders;
 namespace lrm = libsbp_ros_msgs;
 
 GeoTfHandler::GeoTfHandler(const std::shared_ptr<sbp_state_t>& state)
-    : pos_llh_handler_{std::bind(&GeoTfHandler::callbackToPosLlh, this, s::_1,
-                                 s::_2),
-                       SBP_MSG_POS_LLH, state},
-      base_pos_llh_handler_{
+    : base_pos_llh_handler_{
           std::bind(&GeoTfHandler::callbackToBasePosLlh, this, s::_1, s::_2),
           SBP_MSG_BASE_POS_LLH, state} {
+  geotf_.initFromRosParam();
   geotf_.addFrameByEPSG("ecef", 4978);
   geotf_.addFrameByEPSG("wgs84", 4326);
 
   ros::NodeHandle nh_node("~");
-  nh_node.param<bool>("use_base_enu_origin", use_base_enu_origin_,
-                      use_base_enu_origin_);
+  set_enu_origin_srv_ = nh_node.advertiseService(
+      "set_enu_origin", &GeoTfHandler::setEnuOriginCallback, this);
+  reset_enu_origin_srv_ = nh_node.advertiseService(
+      "reset_enu_origin", &GeoTfHandler::resetEnuOriginCallback, this);
 }
 
 void GeoTfHandler::setEnuOriginWgs84(const double lat, const double lon,
@@ -31,28 +31,25 @@ void GeoTfHandler::setEnuOriginWgs84(const double lat, const double lon,
 
 void GeoTfHandler::resetEnuOrigin() { geotf_.removeFrame("enu"); }
 
-void GeoTfHandler::callbackToPosLlh(const msg_pos_llh_t& msg,
-                                    const uint8_t len) {
-  if (use_base_enu_origin_) return;  // Wait for base station position instead.
-  if (geotf_.hasFrame("enu")) return;         // Already set.
-  if (((msg.flags >> 0) & 0x7) == 0) return;  // No nav solution.
-
+void GeoTfHandler::callbackToBasePosLlh(const msg_base_pos_llh_t& msg,
+                                        const uint8_t len) {
+  if (geotf_.hasFrame("enu")) return;  // ENU origin already set.
   Eigen::Vector3d x_wgs84;
-  lrm::convertWgs84Point<msg_pos_llh_t>(msg, &x_wgs84);
+  lrm::convertWgs84Point<msg_base_pos_llh_t>(msg, &x_wgs84);
   geotf_.addFrameByENUOrigin("enu", x_wgs84.x(), x_wgs84.y(), x_wgs84.z());
 }
 
-void GeoTfHandler::callbackToBasePosLlh(const msg_base_pos_llh_t& msg,
-                                        const uint8_t len) {
-  if (!use_base_enu_origin_) return;  // Get base position by other means.
+bool GeoTfHandler::setEnuOriginCallback(
+    piksi_rtk_msgs::EnuOrigin::Request& req,
+    piksi_rtk_msgs::EnuOrigin::Response& res) {
+  setEnuOriginWgs84(req.lat, req.lon, req.alt);
+  return true;
+}
 
-  Eigen::Vector3d x_wgs84;
-  lrm::convertWgs84Point<msg_base_pos_llh_t>(msg, &x_wgs84);
-
-  // Check whether the enu origin needs to be updated.
-  if (!geotf_.hasFrame("enu") || enu_origin_wgs84_ != x_wgs84) {
-    setEnuOriginWgs84(x_wgs84.x(), x_wgs84.y(), x_wgs84.z());
-  }
+bool GeoTfHandler::resetEnuOriginCallback(std_srvs::Empty::Request& req,
+                                          std_srvs::Empty::Response& res) {
+  resetEnuOrigin();
+  return true;
 }
 
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/sbp_callback_handler/geotf_handler.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/geotf_handler.cc
@@ -1,0 +1,34 @@
+#include "piksi_multi_cpp/sbp_callback_handler/geotf_handler.h"
+
+#include <functional>
+
+#include <libsbp_ros_msgs/ros_conversion.h>
+
+namespace piksi_multi_cpp {
+namespace s = std::placeholders;
+namespace lrm = libsbp_ros_msgs;
+
+GeoTfHandler::GeoTfHandler(const std::shared_ptr<sbp_state_t>& state)
+    : pos_llh_handler_{
+          std::bind(&GeoTfHandler::callbackToPosLlh, this, s::_1, s::_2),
+          SBP_MSG_POS_LLH, state} {
+  geotf_.addFrameByEPSG("ecef", 4978);
+  geotf_.addFrameByEPSG("wgs84", 4326);
+
+  ros::NodeHandle nh_node("~");
+  nh_node.param<bool>("use_base_enu_origin", use_base_enu_origin_,
+                      use_base_enu_origin_);
+}
+
+void GeoTfHandler::callbackToPosLlh(const msg_pos_llh_t& msg,
+                                    const uint8_t len) {
+  if (use_base_enu_origin_) return;  // Wait for base station position instead.
+  if (geotf_.hasFrame("enu")) return;         // Already set.
+  if (((msg.flags >> 0) & 0x7) == 0) return;  // No nav solution.
+
+  Eigen::Vector3d x_wgs84;
+  lrm::convertWgs84Point<msg_pos_llh_t>(msg, &x_wgs84);
+  geotf_.addFrameByENUOrigin("enu", x_wgs84.x(), x_wgs84.y(), x_wgs84.z());
+}
+
+}  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/sbp_callback_handler/geotf_handler.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/geotf_handler.cc
@@ -16,8 +16,14 @@ GeoTfHandler::GeoTfHandler(const ros::NodeHandle& nh,
       nh_(nh) {
   geotf_.initFromRosParam();
   if (geotf_.hasFrame("enu")) reset_position_ = ResetEnuOrigin::kNo;
-  geotf_.addFrameByEPSG("ecef", 4978);
-  geotf_.addFrameByEPSG("wgs84", 4326);
+  ROS_ERROR_COND(
+      !geotf_.addFrameByEPSG("ecef", 4978),
+      "Failed to add frame ecef as EPSG:4978. Be careful using converted "
+      "positions");
+  ROS_ERROR_COND(
+      !geotf_.addFrameByEPSG("wgs84", 4326),
+      "Failed to add frame ecef as EPSG:4326. Be careful using converted "
+      "positions");
 
   set_enu_origin_srv_ = nh_.advertiseService(
       "set_enu_origin", &GeoTfHandler::setEnuOriginCallback, this);

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
@@ -3,6 +3,7 @@
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_factory.h"
 
+#include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_ext_event_relay.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_imu_relay.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_mag_relay.h"
@@ -51,6 +52,9 @@ SBPCallbackHandlerFactory::createAllRosMessageRelays(
   relays.push_back(ros_receiver_state);
   relays.push_back(SBPCallbackHandler::Ptr(
       new RosPosLlhCovRelay(nh, state, ros_time_handler, ros_receiver_state)));
+
+  relays.push_back(
+      SBPCallbackHandler::Ptr(new RosPosEnuRelay(nh, state, ros_time_handler)));
 
   return relays;
 }

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
@@ -22,7 +22,8 @@ SBPCallbackHandlerFactory::createAllSBPMessageRelays(
 std::vector<SBPCallbackHandler::Ptr>
 SBPCallbackHandlerFactory::createAllRosMessageRelays(
     const ros::NodeHandle& nh, const std::shared_ptr<sbp_state_t>& state,
-    const RosTimeHandler::Ptr& ros_time_handler) {
+    const RosTimeHandler::Ptr& ros_time_handler,
+    const GeoTfHandler::Ptr& geotf_handler) {
   // Create all relays.
   std::vector<SBPCallbackHandler::Ptr> relays;
 
@@ -53,8 +54,8 @@ SBPCallbackHandlerFactory::createAllRosMessageRelays(
   relays.push_back(SBPCallbackHandler::Ptr(
       new RosPosLlhCovRelay(nh, state, ros_time_handler, ros_receiver_state)));
 
-  relays.push_back(
-      SBPCallbackHandler::Ptr(new RosPosEnuRelay(nh, state, ros_time_handler)));
+  relays.push_back(SBPCallbackHandler::Ptr(
+      new RosPosEnuRelay(nh, state, ros_time_handler, geotf_handler)));
 
   return relays;
 }

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
@@ -1,3 +1,4 @@
+#include <eigen_conversions/eigen_msg.h>
 #include <libsbp_ros_msgs/ros_conversion.h>
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h"
 
@@ -11,8 +12,33 @@ void RosPosEnuRelay::convertSbpMsgToRosMsg(const msg_pos_ecef_t& in,
   ROS_ASSERT(out);
 
   // Convert measurement to Eigen.
-  Eigen::Vector3d x_ecef;
+  Eigen::Vector3d x_ecef, x_enu;
   lrm::convertCartesianPoint<msg_pos_ecef_t>(in, &x_ecef);
+
+  // Update ENU origin if it is not to be set from base station position.
+  if (!use_base_enu_origin_ && !geotf_.hasFrame("enu")) {
+    Eigen::Vector3d x_wgs84;
+    if (!geotf_.convert("ecef", x_ecef, "wgs84", &x_wgs84)) {
+      ROS_ERROR("Failed to convert ECEF to WGS84.");
+      return;
+    }
+    geotf_.addFrameByENUOrigin("enu", x_wgs84.x(), x_wgs84.y(), x_wgs84.z());
+  }
+
+  if (!geotf_.canConvert("ecef", "enu")) {
+    ROS_WARN_THROTTLE(5.0,
+                      "Cannot convert ECEF to ENU. Waiting for ENU to be set.");
+    return;
+  }
+
+  // Convert ECEF to ENU frame.
+  if (!geotf_.convert("ecef", x_ecef, "enu", &x_enu)) {
+    ROS_ERROR("Failed to convert ECEF to ENU.");
+    return;
+  }
+
+  // Save result.
+  tf::pointEigenToMsg(x_enu, out->point);
 }
 
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
@@ -12,7 +12,7 @@ bool RosPosEnuRelay::convertSbpMsgToRosMsg(const msg_pos_ecef_t& in,
                                            geometry_msgs::PointStamped* out) {
   ROS_ASSERT(out);
 
-  // Convert measurement to Eigen.
+  // Convert position.
   Eigen::Vector3d x_ecef, x_enu;
   lrm::convertCartesianPoint<msg_pos_ecef_t>(in, &x_ecef);
 

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
@@ -1,0 +1,3 @@
+#include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h"
+
+namespace piksi_multi_cpp {}

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
@@ -1,5 +1,6 @@
 #include <eigen_conversions/eigen_msg.h>
 #include <libsbp_ros_msgs/ros_conversion.h>
+#include <ros/assert.h>
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h"
 
 namespace piksi_multi_cpp {
@@ -15,29 +16,9 @@ void RosPosEnuRelay::convertSbpMsgToRosMsg(const msg_pos_ecef_t& in,
   Eigen::Vector3d x_ecef, x_enu;
   lrm::convertCartesianPoint<msg_pos_ecef_t>(in, &x_ecef);
 
-  // Update ENU origin if it is not to be set from base station position.
-  if (!use_base_enu_origin_ && !geotf_.hasFrame("enu")) {
-    Eigen::Vector3d x_wgs84;
-    if (!geotf_.convert("ecef", x_ecef, "wgs84", &x_wgs84)) {
-      ROS_ERROR("Failed to convert ECEF to WGS84.");
-      return;
-    }
-    geotf_.addFrameByENUOrigin("enu", x_wgs84.x(), x_wgs84.y(), x_wgs84.z());
-  }
+  updateEnuOriginFromEcef(x_ecef);
+  convertPositionEcefToEnu(x_ecef, &x_enu);
 
-  if (!geotf_.canConvert("ecef", "enu")) {
-    ROS_WARN_THROTTLE(5.0,
-                      "Cannot convert ECEF to ENU. Waiting for ENU to be set.");
-    return;
-  }
-
-  // Convert ECEF to ENU frame.
-  if (!geotf_.convert("ecef", x_ecef, "enu", &x_enu)) {
-    ROS_ERROR("Failed to convert ECEF to ENU.");
-    return;
-  }
-
-  // Save result.
   tf::pointEigenToMsg(x_enu, out->point);
 }
 

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
@@ -1,3 +1,18 @@
+#include <libsbp_ros_msgs/ros_conversion.h>
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h"
 
-namespace piksi_multi_cpp {}
+namespace piksi_multi_cpp {
+
+namespace lrm = libsbp_ros_msgs;
+
+void RosPosEnuRelay::convertSbpMsgToRosMsg(const msg_pos_ecef_t& in,
+                                           const uint8_t len,
+                                           geometry_msgs::PointStamped* out) {
+  ROS_ASSERT(out);
+
+  // Convert measurement to Eigen.
+  Eigen::Vector3d x_ecef;
+  lrm::convertCartesianPoint<msg_pos_ecef_t>(in, &x_ecef);
+}
+
+}  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_relays.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_relays.cc
@@ -9,14 +9,15 @@ namespace piksi_multi_cpp {
 namespace lrm = libsbp_ros_msgs;
 namespace gm = geometry_msgs;
 
-void RosPosEcefRelay::convertSbpMsgToRosMsg(const msg_pos_ecef_t& in,
+bool RosPosEcefRelay::convertSbpMsgToRosMsg(const msg_pos_ecef_t& in,
                                             const uint8_t len,
                                             geometry_msgs::PointStamped* out) {
   ROS_ASSERT(out);
   lrm::convertCartesianPoint<msg_pos_ecef_t, gm::Point>(in, &(out->point));
+  return true;
 }
 
-void RosPosEcefCovRelay::convertSbpMsgToRosMsg(
+bool RosPosEcefCovRelay::convertSbpMsgToRosMsg(
     const msg_pos_ecef_cov_t& in, const uint8_t len,
     piksi_rtk_msgs::PositionWithCovarianceStamped* out) {
   ROS_ASSERT(out);
@@ -24,9 +25,10 @@ void RosPosEcefCovRelay::convertSbpMsgToRosMsg(
       in, &(out->position.position));
   lrm::convertCartesianCov<msg_pos_ecef_cov_t, boost::array<double, 9>>(
       in, &(out->position.covariance));
+  return true;
 }
 
-void RosPosLlhCovRelay::convertSbpMsgToRosMsg(const msg_pos_llh_cov_t& in,
+bool RosPosLlhCovRelay::convertSbpMsgToRosMsg(const msg_pos_llh_cov_t& in,
                                               const uint8_t len,
                                               sensor_msgs::NavSatFix* out) {
   ROS_ASSERT(out);
@@ -49,19 +51,24 @@ void RosPosLlhCovRelay::convertSbpMsgToRosMsg(const msg_pos_llh_cov_t& in,
     default:
       ROS_ERROR("Cannot infer fix status.");
       out->status.status = sensor_msgs::NavSatStatus::STATUS_NO_FIX;
+      return false;
   }
 
   if (ros_receiver_state_.get()) {
     out->status.service = ros_receiver_state_->getNavSatServiceStatus();
+  } else {
+    return false;
   }
 
   lrm::convertWgs84Point<msg_pos_llh_cov_t, sensor_msgs::NavSatFix>(in, out);
   lrm::convertNedCov<msg_pos_llh_cov_t, boost::array<double, 9>>(
       in, &(out->position_covariance));
   out->position_covariance_type = sensor_msgs::NavSatFix::COVARIANCE_TYPE_KNOWN;
+
+  return true;
 }
 
-void RosBaselineNedRelay::convertSbpMsgToRosMsg(
+bool RosBaselineNedRelay::convertSbpMsgToRosMsg(
     const msg_baseline_ned_t& in, const uint8_t len,
     piksi_rtk_msgs::PositionWithCovarianceStamped* out) {
   ROS_ASSERT(out);
@@ -69,16 +76,18 @@ void RosBaselineNedRelay::convertSbpMsgToRosMsg(
       in, &(out->position.position));
   lrm::convertNedAccuracyToNedCov<msg_baseline_ned_t, boost::array<double, 9>>(
       in, &(out->position.covariance));
+  return true;
 }
 
-void RosVelEcefRelay::convertSbpMsgToRosMsg(const msg_vel_ecef_t& in,
+bool RosVelEcefRelay::convertSbpMsgToRosMsg(const msg_vel_ecef_t& in,
                                             const uint8_t len,
                                             gm::Vector3Stamped* out) {
   ROS_ASSERT(out);
   lrm::convertCartesianVector<msg_vel_ecef_t, gm::Vector3>(in, &(out->vector));
+  return true;
 }
 
-void RosVelEcefCovRelay::convertSbpMsgToRosMsg(
+bool RosVelEcefCovRelay::convertSbpMsgToRosMsg(
     const msg_vel_ecef_cov_t& in, const uint8_t len,
     piksi_rtk_msgs::VelocityWithCovarianceStamped* out) {
   ROS_ASSERT(out);
@@ -86,16 +95,18 @@ void RosVelEcefCovRelay::convertSbpMsgToRosMsg(
       in, &(out->velocity.velocity));
   lrm::convertCartesianCovMm<msg_vel_ecef_cov_t, boost::array<double, 9>>(
       in, &(out->velocity.covariance));
+  return true;
 }
 
-void RosVelNedRelay::convertSbpMsgToRosMsg(const msg_vel_ned_t& in,
+bool RosVelNedRelay::convertSbpMsgToRosMsg(const msg_vel_ned_t& in,
                                            const uint8_t len,
                                            gm::Vector3Stamped* out) {
   ROS_ASSERT(out);
   lrm::convertNedVector<msg_vel_ned_t, gm::Vector3>(in, &(out->vector));
+  return true;
 }
 
-void RosVelNedCovRelay::convertSbpMsgToRosMsg(
+bool RosVelNedCovRelay::convertSbpMsgToRosMsg(
     const msg_vel_ned_cov_t& in, const uint8_t len,
     piksi_rtk_msgs::VelocityWithCovarianceStamped* out) {
   ROS_ASSERT(out);
@@ -103,6 +114,7 @@ void RosVelNedCovRelay::convertSbpMsgToRosMsg(
       in, &(out->velocity.velocity));
   lrm::convertNedCovMm<msg_vel_ned_cov_t, boost::array<double, 9>>(
       in, &(out->velocity.covariance));
+  return true;
 }
 
 }  // namespace piksi_multi_cpp

--- a/piksi_rtk_msgs/CMakeLists.txt
+++ b/piksi_rtk_msgs/CMakeLists.txt
@@ -68,6 +68,7 @@ add_message_files(
 ## Generate services in the 'srv' folder
 add_service_files(
   FILES
+    EnuOrigin.srv
     SamplePosition.srv
     SettingsWrite.srv
     SettingsReadReq.srv

--- a/piksi_rtk_msgs/srv/EnuOrigin.srv
+++ b/piksi_rtk_msgs/srv/EnuOrigin.srv
@@ -1,0 +1,4 @@
+float64 lat
+float64 lon
+float64 alt
+---


### PR DESCRIPTION
One approach to publish a position in ENU frame. Does not implement enu with covariance, yet. 

- Every receiver owns a geotf handler
- This geotf handler has an ENU frame that can be set through a service either
  - To a defined position
  - To the current position
  - To the base station position (not tested)

https://github.com/ethz-asl/ethz_piksi_ros/pull/125 and https://github.com/ethz-asl/geodetic_utils/pull/40 should be merged first. Addresses ENU publishing in https://github.com/ethz-asl/ethz_piksi_ros/issues/102.