### PR TITLE
Adding transform stamped

### DIFF
--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
@@ -39,7 +39,7 @@ class RosEnuRelay : public RosRelay<SbpMsgType, RosMsgType> {
  protected:
   inline bool convertEcefToEnu(const SbpMsgType& in,
                                Eigen::Vector3d* x_enu) const {
-    ROS_ASSERT(out);
+    ROS_ASSERT(x_enu);
 
     // Convert position.
     Eigen::Vector3d x_ecef;

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
@@ -7,7 +7,9 @@
 #include <Eigen/Dense>
 #include <optional>
 
+#include <geometry_msgs/Point.h>
 #include <geometry_msgs/PointStamped.h>
+#include <geometry_msgs/Vector3.h>
 #include <piksi_rtk_msgs/PositionWithCovarianceStamped.h>
 
 #include "piksi_multi_cpp/sbp_callback_handler/geotf_handler.h"
@@ -36,19 +38,39 @@ class RosEnuRelay : public RosRelay<SbpMsgType, RosMsgType> {
 
  protected:
   inline bool convertEcefToEnu(const SbpMsgType& in,
-                               geometry_msgs::Point* out) const {
+                               Eigen::Vector3d* x_enu) const {
     ROS_ASSERT(out);
 
     // Convert position.
-    Eigen::Vector3d x_ecef, x_enu;
+    Eigen::Vector3d x_ecef;
     libsbp_ros_msgs::convertCartesianPoint<msg_pos_ecef_t>(in, &x_ecef);
 
     if (!geotf_handler_.get()) return false;
-    if (!geotf_handler_->getGeoTf().convert("ecef", x_ecef, "enu", &x_enu))
+    if (!geotf_handler_->getGeoTf().convert("ecef", x_ecef, "enu", x_enu))
       return false;
 
-    tf::pointEigenToMsg(x_enu, *out);
+    return true;
+  }
 
+  inline bool convertEcefToEnu(const SbpMsgType& in,
+                               geometry_msgs::Point* out) {
+    ROS_ASSERT(out)
+
+    Eigen::Vector3d x_enu;
+    if (!convertEcefToEnu(in, &x_enu)) return false;
+
+    tf::pointEigenToMsg(x_enu, *out);
+    return true;
+  }
+
+  inline bool convertEcefToEnu(const SbpMsgType& in,
+                               geometry_msgs::Vector3* out) {
+    ROS_ASSERT(out)
+
+    Eigen::Vector3d x_enu;
+    if (!convertEcefToEnu(in, &x_enu)) return false;
+
+    tf::vectorEigenToMsg(x_enu, *out);
     return true;
   }
 
@@ -68,6 +90,21 @@ class RosPosEnuRelay
  private:
   bool convertSbpMsgToRosMsg(const msg_pos_ecef_t& in, const uint8_t len,
                              geometry_msgs::PointStamped* out) override;
+};
+
+class RosTransformEnuRelay
+    : public RosEnuRelay<msg_pos_ecef_t, geometry_msgs::TransformStamped> {
+ public:
+  inline RosTransformEnuRelay(const ros::NodeHandle& nh,
+                              const std::shared_ptr<sbp_state_t>& state,
+                              const RosTimeHandler::Ptr& ros_time_handler,
+                              const GeoTfHandler::Ptr& geotf_handler)
+      : RosEnuRelay(nh, SBP_MSG_POS_ECEF, state, "transform_enu",
+                    ros_time_handler, geotf_handler) {}
+
+ private:
+  bool convertSbpMsgToRosMsg(const msg_pos_ecef_t& in, const uint8_t len,
+                             geometry_msgs::TransformStamped* out) override;
 };
 
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
@@ -56,6 +56,8 @@ SBPCallbackHandlerFactory::createAllRosMessageRelays(
 
   relays.push_back(SBPCallbackHandler::Ptr(
       new RosPosEnuRelay(nh, state, ros_time_handler, geotf_handler)));
+  relays.push_back(SBPCallbackHandler::Ptr(
+      new RosTransformEnuRelay(nh, state, ros_time_handler, geotf_handler)));
 
   return relays;
 }

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
@@ -10,4 +10,12 @@ bool RosPosEnuRelay::convertSbpMsgToRosMsg(const msg_pos_ecef_t& in,
   return convertEcefToEnu(in, &out->point);
 }
 
+bool RosTransformEnuRelay::convertSbpMsgToRosMsg(
+    const msg_pos_ecef_t& in, const uint8_t len,
+    geometry_msgs::TransformStamped* out) {
+  ROS_ASSERT(out);
+
+  return convertEcefToEnu(in, &out->transform.translation);
+}
+
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
@@ -15,8 +15,12 @@ bool RosTransformEnuRelay::convertSbpMsgToRosMsg(
     geometry_msgs::TransformStamped* out) {
   ROS_ASSERT(out);
 
+  if (!convertEcefToEnu(in, &out->transform.translation)) return false;
+
   // TODO(rikba): Also add orientation information if available.
-  return convertEcefToEnu(in, &out->transform.translation);
+  out->transform.rotation.w = 1.0;
+
+  return true;
 }
 
 }  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
@@ -15,6 +15,7 @@ bool RosTransformEnuRelay::convertSbpMsgToRosMsg(
     geometry_msgs::TransformStamped* out) {
   ROS_ASSERT(out);
 
+  // TODO(rikba): Also add orientation information if available.
   return convertEcefToEnu(in, &out->transform.translation);
 }
 

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
@@ -1,27 +1,13 @@
-#include <eigen_conversions/eigen_msg.h>
-#include <libsbp_ros_msgs/ros_conversion.h>
-#include <ros/assert.h>
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h"
 
 namespace piksi_multi_cpp {
-
-namespace lrm = libsbp_ros_msgs;
 
 bool RosPosEnuRelay::convertSbpMsgToRosMsg(const msg_pos_ecef_t& in,
                                            const uint8_t len,
                                            geometry_msgs::PointStamped* out) {
   ROS_ASSERT(out);
 
-  // Convert position.
-  Eigen::Vector3d x_ecef, x_enu;
-  lrm::convertCartesianPoint<msg_pos_ecef_t>(in, &x_ecef);
-
-  if (!geotf_handler_.get()) return false;
-  if (!geotf_handler_->getGeoTf().convert("ecef", x_ecef, "enu", &x_enu))
-    return false;
-
-  tf::pointEigenToMsg(x_enu, out->point);
-  return true;
+  return convertEcefToEnu(in, &out->point);
 }
 
 }  // namespace piksi_multi_cpp


### PR DESCRIPTION
Adding `geometry_msgs/TransformStamped` in ENU frame as output of driver. Not a fan, since the rotation field is not populated by Piksi Multi, but unfortunately MAVROS and ROVIO do not subscribe to PointStamped.