### PR TITLE
Fix/startup

### DIFF
--- a/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_factory.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_factory.h
@@ -30,7 +30,8 @@ class ReceiverFactory {
     kAttitudeReceiver,
     kSettingIo,  // An abstract receiver that allows reading and writing
                  // settings.
-    kUnknown
+    kUnknown,
+    kError // Occurs when unable to open device.
   };
   // Factory method to create a receiver by setting node handle, hardware
   // device, and receiver type.

--- a/piksi_multi_cpp/src/piksi_multi_node.cc
+++ b/piksi_multi_cpp/src/piksi_multi_node.cc
@@ -20,8 +20,6 @@ int main(int argc, char** argv) {
   if (receivers.empty()) {
     ROS_FATAL("No receivers.");
     exit(1);
-  } else {
-    ROS_INFO("Created %d receivers.", receivers.size());
   }
 
   // Start all receivers.

--- a/piksi_multi_cpp/src/piksi_multi_node.cc
+++ b/piksi_multi_cpp/src/piksi_multi_node.cc
@@ -20,6 +20,8 @@ int main(int argc, char** argv) {
   if (receivers.empty()) {
     ROS_FATAL("No receivers.");
     exit(1);
+  } else {
+    ROS_INFO("Created %d receivers.", receivers.size());
   }
 
   // Start all receivers.

--- a/piksi_multi_cpp/src/receiver/receiver_factory.cc
+++ b/piksi_multi_cpp/src/receiver/receiver_factory.cc
@@ -23,6 +23,8 @@ Receiver::Ptr ReceiverFactory::createReceiverByReceiverType(
       return Receiver::Ptr(new SettingsIo(device));
     case ReceiverType::kUnknown:
       return Receiver::Ptr(new ReceiverRos(nh, device));
+    case ReceiverType::kError:
+      return nullptr;
     default:
       return nullptr;
   }
@@ -105,11 +107,11 @@ std::string ReceiverFactory::createNameSpace(const ReceiverType type,
 
 ReceiverFactory::ReceiverType ReceiverFactory::inferType(
     const Device::Ptr& dev) {
-  if (!dev.get()) return ReceiverType::kUnknown;
+  if (!dev.get()) return ReceiverType::kError;
 
   // Create settings object.
   SettingsIo settings_io(dev);
-  if (!settings_io.init()) return ReceiverType::kUnknown;
+  if (!settings_io.init()) return ReceiverType::kError;
 
   // Identify base station.
   while (!settings_io.readSetting("surveyed_position", "broadcast")) {

--- a/piksi_multi_cpp/src/receiver/receiver_factory.cc
+++ b/piksi_multi_cpp/src/receiver/receiver_factory.cc
@@ -48,6 +48,7 @@ ReceiverFactory::createAllReceiversByIdentifiersAndNaming(
   std::vector<std::shared_ptr<Receiver>> receivers;
   for (auto dev : devices) {
     ReceiverType type = inferType(dev);
+    if (type == ReceiverType::kError) continue;
     // Initialize counter
     if (counter.find(type) == counter.end()) {
       // Initialize type counter.


### PR DESCRIPTION
If an interface was selected by the user but the interface was not hooked up, e.g., piksi on ethernet connection, the driver would still have created a receiver. This PR catches these invalid devices and does not create them in the first place.