### PR TITLE
Feature/status indicator

### DIFF
--- a/ethz_piksi_ros/package.xml
+++ b/ethz_piksi_ros/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>piksi_rtk_msgs</exec_depend>
   <!--exec_depend>piksi_v2_rtk_ros</exec_depend-->
   <exec_depend>rqt_gps_rtk_plugin</exec_depend>
+  <exec_depend>piksi_status_indicator</exec_depend>
 
   <export>
     <metapackage />

--- a/piksi_status_indicator/CMakeLists.txt
+++ b/piksi_status_indicator/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(piksi_status_indicator)
+
+find_package(catkin REQUIRED
+  COMPONENTS
+    piksi_rtk_msgs
+    neostate
+    rospy
+)
+
+catkin_package(
+  CATKIN_DEPENDS
+    piksi_rtk_msgs
+    neostate
+    rospy
+)
+
+catkin_python_setup()
+
+catkin_install_python(PROGRAMS scripts/start_status_indicator
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/piksi_status_indicator/install/98-arduino.rules
+++ b/piksi_status_indicator/install/98-arduino.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="tty", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="8037", SYMLINK+="arduino"
+

--- a/piksi_status_indicator/install/install_indicator_autostart.sh
+++ b/piksi_status_indicator/install/install_indicator_autostart.sh
@@ -1,0 +1,23 @@
+# Install service.
+echo "Do you wish to configure led status indicator autostart? [y or Y to accept]"
+read configure_base_autostart
+if [[ $configure_base_autostart == "Y" || $configure_base_autostart == "y" ]]; then
+  echo "Configuring /etc/systemd/system/led_status_indicator.service"
+  sudo rm /etc/systemd/system/led_status_indicator.service
+  sudo sh -c "tee -a /etc/systemd/system/led_status_indicator.service << END
+[Unit]
+Description=Start led status indicator and rosserial connection with arduino board automatically on startup.
+
+[Service]
+Type=forking
+ExecStart=/home/$USER/catkin_ws/src/ethz_piksi_ros/piksi_status_indicator/install/startup_led_indicator.sh
+Restart=on-failure
+User=$USER
+
+[Install]
+WantedBy=multi-user.target
+END"
+fi
+
+sudo systemctl daemon-reload
+sudo systemctl enable led_status_indicator

--- a/piksi_status_indicator/install/startup_led_indicator.sh
+++ b/piksi_status_indicator/install/startup_led_indicator.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source /home/$USER/catkin_ws/devel/setup.bash
+roslaunch piksi_status_indicator indicator.launch &

--- a/piksi_status_indicator/install/startup_led_indicator.sh
+++ b/piksi_status_indicator/install/startup_led_indicator.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 source /home/$USER/catkin_ws/devel/setup.bash
-roslaunch piksi_status_indicator indicator.launch &
+
+roslaunch piksi_status_indicator indicator.launch

--- a/piksi_status_indicator/launch/indicator.launch
+++ b/piksi_status_indicator/launch/indicator.launch
@@ -1,0 +1,10 @@
+<launch>
+  <node name="piksi_multi_cpp_base" pkg="piksi_status_indicator" type="start_status_indicator" output="screen" required="true">
+      <param name="number_of_leds" value="8" />
+  </node>
+
+  <!-- Run Status Indicator Link. -->
+  <node name="rosserial_python" pkg="rosserial_python" type="serial_node.py"
+    args="_port:=/dev/ttyACM0 _baud:=56700" respawn="true" output="screen" />
+
+</launch>

--- a/piksi_status_indicator/launch/indicator.launch
+++ b/piksi_status_indicator/launch/indicator.launch
@@ -1,9 +1,9 @@
 <launch>
-<node name="piksi_status_indicator" pkg="piksi_status_indicator" type="start_status_indicator" output="screen" required="true">
+<node name="piksi_status_indicator" pkg="piksi_status_indicator" type="start_status_indicator" output="log" required="true">
       <param name="number_of_leds" value="8" />
   </node>
   <!-- Run Status Indicator Link. -->
-  <node name="rosserial_python" pkg="rosserial_python" type="serial_node.py"
-    args="_port:=/dev/ttyACM0 _baud:=57600" respawn="true" output="screen" />
+  <node name="rosserial_server" pkg="rosserial_server" type="serial_node"
+    args="_port:=/dev/arduino _baud:=57600" respawn="false" output="log" required="true" />
 
 </launch>

--- a/piksi_status_indicator/launch/indicator.launch
+++ b/piksi_status_indicator/launch/indicator.launch
@@ -1,10 +1,9 @@
 <launch>
-  <node name="piksi_multi_cpp_base" pkg="piksi_status_indicator" type="start_status_indicator" output="screen" required="true">
+<node name="piksi_status_indicator" pkg="piksi_status_indicator" type="start_status_indicator" output="screen" required="true">
       <param name="number_of_leds" value="8" />
   </node>
-
   <!-- Run Status Indicator Link. -->
   <node name="rosserial_python" pkg="rosserial_python" type="serial_node.py"
-    args="_port:=/dev/ttyACM0 _baud:=56700" respawn="true" output="screen" />
+    args="_port:=/dev/ttyACM0 _baud:=57600" respawn="true" output="screen" />
 
 </launch>

--- a/piksi_status_indicator/package.xml
+++ b/piksi_status_indicator/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>piksi_status_indicator</name>
+  <version>1.0.0</version>
+  <description>
+    ROS script which uses the neostate package to indicate the status of the base station.
+  </description>
+
+  <author email="christian.lanegger@mavt.ethz.ch">Christian Lanegger</author>
+  <maintainer email="christian.lanegger@mavt.ethz.ch">Christian Lanegger</maintainer>
+  
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>piksi_rtk_msgs</depend>
+  <depend>roslib</depend>
+  <depend>rospy</depend>
+  <depend>neostate</depend>
+
+</package>

--- a/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator
+++ b/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator
@@ -1,0 +1,1 @@
+#!/usr/bin/env python

--- a/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator
+++ b/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator
@@ -1,1 +1,0 @@
-#!/usr/bin/env python

--- a/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator.py
+++ b/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+
+import rospy
+from piksi_rtk_msgs.msg import PositionWithCovarianceStamped, ReceiverState_V2_4_1
+from neostate.msg import StatusLEDArray, StatusLED
+
+
+class LEDArray(object):
+    def __init__(self, num_leds):
+        self.__num_of_leds = num_leds
+
+        # LED status:
+        #    0: off
+        #   -1: on
+        #   >0: blinking at frequency specified in array
+        self.__led_status = [0] * self.__num_of_leds
+
+        # Store RGB value for every LED
+        self.__led_colors = [[0, 0, 0]] * self.__num_of_leds
+
+    @property
+    def led_status(self):
+        return self.__led_status
+
+    @property
+    def led_colors(self):
+        return self.__led_colors
+
+    @led_status.setter
+    def led_status(self, ids, status, rgb_color):
+        if len(ids) is not len(status) is not len(rgb_color):
+            rospy.logwarn(
+                "[Piksi Status Indicator]: " 
+                + "Cannot assign values to ids as their array size is not the same."
+                + "Not changing LED status."
+            )
+            return
+        elif len(ids) > len(self.__led_status):
+            rospy.logwarn(
+                "[Piksi Status Indicator]:"
+                + "It is not possible to assign more values than leds."
+                + "Not changing LED status."
+            )
+            return
+
+        for id, stat_val, color in zip(range(ids), range(status), range(rgb_color)):
+            self.__led_status[id] = stat_val
+            if stat_val is not 0:
+                self.__led_colors[id] = color
+            else:
+                # turn off led
+                self.__led_colors[id] = [0, 0, 0]
+
+    def get_num_leds(self):
+        return self.__num_of_leds
+
+
+class BaseStationIndicator(object):
+    def __init__(self):
+        rospy.init_node("piksi_status_indicator")
+
+        self.kf_pos_sub_ = rospy.Subscriber(
+            "position_sampler/kf_position",
+            PositionWithCovarianceStamped,
+            self.set_sampling_indicators,
+            queue_size=1,
+        )
+        self.ml_pos_sub_ = rospy.Subscriber(
+            "position_sampler/ml_position",
+            PositionWithCovarianceStamped,
+            self.set_finish_survey_indicators,
+            queue_size=1,
+        )
+        self.recv_state_sub_ = rospy.Subscriber(
+            "debug/receiver_state",
+            ReceiverState_V2_4_1,
+            self.set_statelllite_indicators,
+            queue_size=1,
+        )
+        self.ind_pub_ = rospy.Publisher("set_status_led_array", StatusLEDArray, queue_size=1)
+
+        while not rospy.has_param("piksi_multi_cpp_base/num_desired_fixes"):
+            rospy.logwarn_throttle(5, "[Piksi Status Indicator]: Waiting for <num_desired_fixes> param")
+        self.desired_fixes_ = rospy.get_param("piksi_multi_cpp_base/num_desired_fixes")
+
+        num_leds = rospy.get_param("number_of_leds")
+        self.indicator = LEDArray(num_leds)
+
+        self.green_color_ = [0, 155, 0]
+        self.blue_color_ = [0, 0, 155]
+
+    def run(self):
+        rospy.loginfo("[Piksi Status Indicator]: Starting base station LED indicator..")
+        rospy.spin()
+
+    def update_indicator_state(self):
+        msg = StatusLEDArray()
+        led_stat_msg = StatusLED()
+
+        for status, color in zip(
+            range(self.indicator.led_status), range(self.indicator.led_colors)
+        ):
+            led_stat_msg.red = color[0]
+            led_stat_msg.green = color[1]
+            led_stat_msg.blue = color[2]
+
+            if status > 0:
+                led_stat_msg.blinking = True
+            else:
+                led_stat_msg.blinking = False
+
+    def set_sampling_indicators(self, msg):
+        curr_seq = msg.header.seq
+
+        # look for the blinking led (last one):
+        blink_id = next((x for x in self.indicator.led_status() if x > 0), 0)
+
+        # Split leds depending on total desired fixes on how many leds are available
+        if (
+            msg.header.seq
+            >= self.desired_fixes_ / self.indicator.get_num_leds() * led_id
+        ):
+            # add new led blinking and set the one before to on
+            self.indicator.led_status(blink_id, 4, self.green_color_)
+            if led_id > 0:
+                self.indicator.led_status(blink_id - 1, -1, self.green_color_)
+            update_indicator_state()
+
+    def set_finish_survey_indicators(self, msg):
+        # Survey finished. Set last led to on and wait for 3 seconds
+        self.indicator.led_status(
+            self.indicator.get_num_leds() - 1, -1, self.green_color_
+        )
+        update_indicator_state()
+        rospy.sleep(3)
+
+    def set_statelllite_indicators(self, msg):
+        pass

--- a/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator.py
+++ b/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator.py
@@ -28,8 +28,8 @@ class BaseStationIndicator(object):
         self.finished_sampling = False
         self.finished_survey = False
 
-        self.green_color_ = [0, 10, 0] 
-        self.blue_color_ = [0, 0, 10] 
+        self.green_color_ = [0, 155, 0] 
+        self.blue_color_ = [0, 0, 155] 
         
         #TODO(clanegge): Search for namespace of base station
         self.kf_pos_sub_ = rospy.Subscriber(

--- a/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator.py
+++ b/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator.py
@@ -26,8 +26,7 @@ class LEDArray(object):
     def led_colors(self):
         return self.__led_colors
 
-    @led_status.setter
-    def led_status(self, ids, status, rgb_color):
+    def set_led_status(self, ids, status, rgb_color):
         if len(ids) is not len(status) is not len(rgb_color):
             rospy.logwarn(
                 "[Piksi Status Indicator]: " 
@@ -43,11 +42,13 @@ class LEDArray(object):
             )
             return
 
-        for id, stat_val, color in zip(range(ids), range(status), range(rgb_color)):
+        for id, stat_val, color in zip(ids, status, rgb_color):
             self.__led_status[id] = stat_val
             if stat_val is not 0:
+                rospy.logwarn("Setting led to color %i", id)
                 self.__led_colors[id] = color
             else:
+                rospy.logwarn("turning of led %i", id)
                 # turn off led
                 self.__led_colors[id] = [0, 0, 0]
 
@@ -58,36 +59,36 @@ class LEDArray(object):
 class BaseStationIndicator(object):
     def __init__(self):
         rospy.init_node("piksi_status_indicator")
-
         self.kf_pos_sub_ = rospy.Subscriber(
-            "position_sampler/kf_position",
+            "/piksi_multi_cpp_base/base_station_receiver_0/position_sampler/kf_position",
             PositionWithCovarianceStamped,
             self.set_sampling_indicators,
             queue_size=1,
         )
         self.ml_pos_sub_ = rospy.Subscriber(
-            "position_sampler/ml_position",
+            "/piksi_multi_cpp_base/base_station_receiver_0/position_sampler/ml_position",
             PositionWithCovarianceStamped,
             self.set_finish_survey_indicators,
             queue_size=1,
         )
         self.recv_state_sub_ = rospy.Subscriber(
-            "debug/receiver_state",
+            "/piksi_multi_cpp_base/base_station_receiver_0/debug/receiver_state",
             ReceiverState_V2_4_1,
             self.set_statelllite_indicators,
             queue_size=1,
         )
-        self.ind_pub_ = rospy.Publisher("set_status_led_array", StatusLEDArray, queue_size=1)
+
+        self.ind_pub_ = rospy.Publisher("set_status_led_array", StatusLEDArray, queue_size=1, latch=True)
 
         while not rospy.has_param("piksi_multi_cpp_base/num_desired_fixes"):
             rospy.logwarn_throttle(5, "[Piksi Status Indicator]: Waiting for <num_desired_fixes> param")
         self.desired_fixes_ = rospy.get_param("piksi_multi_cpp_base/num_desired_fixes")
 
-        num_leds = rospy.get_param("number_of_leds")
+        num_leds = rospy.get_param("~number_of_leds")
         self.indicator = LEDArray(num_leds)
-
-        self.green_color_ = [0, 155, 0]
-        self.blue_color_ = [0, 0, 155]
+        self.brightness = 0.1
+        self.green_color_ = [0, 10, 0] 
+        self.blue_color_ = [0, 0, 10] 
 
     def run(self):
         rospy.loginfo("[Piksi Status Indicator]: Starting base station LED indicator..")
@@ -95,43 +96,42 @@ class BaseStationIndicator(object):
 
     def update_indicator_state(self):
         msg = StatusLEDArray()
-        led_stat_msg = StatusLED()
-
         for status, color in zip(
-            range(self.indicator.led_status), range(self.indicator.led_colors)
+            self.indicator.led_status, self.indicator.led_colors
         ):
+            led_stat_msg = StatusLED()
             led_stat_msg.red = color[0]
             led_stat_msg.green = color[1]
             led_stat_msg.blue = color[2]
-
             if status > 0:
                 led_stat_msg.blinking = True
             else:
                 led_stat_msg.blinking = False
+            msg.LED_array.append(led_stat_msg)
+        self.ind_pub_.publish(msg)
 
     def set_sampling_indicators(self, msg):
         curr_seq = msg.header.seq
 
-        # look for the blinking led (last one):
-        blink_id = next((x for x in self.indicator.led_status() if x > 0), 0)
-
+        # look for the first not blinking led:
+        blink_id = next((idx for idx, val in enumerate(self.indicator.led_status) if val is 0), None)
         # Split leds depending on total desired fixes on how many leds are available
-        if (
+        if (blink_id is not None and
             msg.header.seq
-            >= self.desired_fixes_ / self.indicator.get_num_leds() * led_id
+            >= self.desired_fixes_ / self.indicator.get_num_leds() * blink_id
         ):
             # add new led blinking and set the one before to on
-            self.indicator.led_status(blink_id, 4, self.green_color_)
-            if led_id > 0:
-                self.indicator.led_status(blink_id - 1, -1, self.green_color_)
-            update_indicator_state()
+            self.indicator.set_led_status([blink_id], [4], [self.green_color_])
+            if blink_id > 0:
+                self.indicator.set_led_status([blink_id - 1], [-1], [self.green_color_])
+            self.update_indicator_state()
 
     def set_finish_survey_indicators(self, msg):
         # Survey finished. Set last led to on and wait for 3 seconds
-        self.indicator.led_status(
-            self.indicator.get_num_leds() - 1, -1, self.green_color_
+        self.indicator.set_led_status(
+            [self.indicator.get_num_leds() - 1], [-1], [self.green_color_]
         )
-        update_indicator_state()
+        self.update_indicator_state()
         rospy.sleep(3)
 
     def set_statelllite_indicators(self, msg):

--- a/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator.py
+++ b/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python
 
 import rospy
-from piksi_rtk_msgs.msg import PositionWithCovarianceStamped, ReceiverState_V2_4_1
+
+from piksi_rtk_msgs.msg import PositionWithCovarianceStamped, ReceiverState_V2_6_5
 from neostate.led_array import LEDArray
 
 
 class BaseStationIndicator(object):
+    """Base Station Indicator using the Neostate package.
+
+    During survey the leds will increasingly turn green until the sampling has finished.
+    Once finished the leds will stay green for 3 seconds and then use blue indicators
+    to show how many satellites the base station is seeing (more than 35 satellites results
+    in all leds turned on).
+    If the blue indicators are blinking, then the base station fixed mode is not in SBAS. 
+    """
     def __init__(self):
         rospy.init_node("piksi_status_indicator")
 
@@ -15,56 +24,118 @@ class BaseStationIndicator(object):
 
         num_leds = rospy.get_param("~number_of_leds")
         self.indicator = LEDArray(num_leds)
-        self.brightness = 0.1
+        
+        self.finished_sampling = False
+        self.finished_survey = False
+
         self.green_color_ = [0, 10, 0] 
         self.blue_color_ = [0, 0, 10] 
-
+        
+        #TODO(clanegge): Search for namespace of base station
         self.kf_pos_sub_ = rospy.Subscriber(
             "/piksi_multi_cpp_base/base_station_receiver_0/position_sampler/kf_position",
             PositionWithCovarianceStamped,
             self.set_sampling_indicators,
             queue_size=1,
         )
-        self.ml_pos_sub_ = rospy.Subscriber(
-            "/piksi_multi_cpp_base/base_station_receiver_0/position_sampler/ml_position",
-            PositionWithCovarianceStamped,
-            self.set_finish_survey_indicators,
-            queue_size=1,
-        )
+
         self.recv_state_sub_ = rospy.Subscriber(
-            "/piksi_multi_cpp_base/base_station_receiver_0/debug/receiver_state",
-            ReceiverState_V2_4_1,
-            self.set_statelllite_indicators,
+            "piksi_multi_cpp_base/base_station_receiver_0/ros/receiver_state",
+            ReceiverState_V2_6_5,
+            self.set_satellite_indicators,
             queue_size=1,
         )
+
+        # Turn off all leds to indicate script is running
+        self.indicator.turn_off_all_leds()
+
 
     def run(self):
         rospy.loginfo("[Piksi Status Indicator]: Starting base station LED indicator..")
         rospy.spin()
+    
+    def get_next_off_led(self):
+        return  next((idx for idx, val in enumerate(self.indicator.led_status) if val is 0), None)
 
     def set_sampling_indicators(self, msg):
-        curr_seq = msg.header.seq
+        if msg.header.seq == (self.desired_fixes_ -1):
+            # Sampling finished 
+            self.finished_sampling = True
+            self.ml_pos_sub_ = rospy.Subscriber(
+            "/piksi_multi_cpp_base/base_station_receiver_0/position_sampler/ml_position",
+            PositionWithCovarianceStamped,
+            self.set_finish_survey_indicators,
+            queue_size=1,
+            )
 
-        # look for the first not blinking led:
-        blink_id = next((idx for idx, val in enumerate(self.indicator.led_status) if val is 0), None)
-        # Split leds depending on total desired fixes on how many leds are available
-        if (blink_id is not None and
-            msg.header.seq
-            >= self.desired_fixes_ / self.indicator.get_num_leds() * blink_id
-        ):
-            # add new led blinking and set the one before to on
-            self.indicator.set_led_status([blink_id], [4], [self.green_color_])
-            if blink_id > 0:
-                self.indicator.set_led_status([blink_id - 1], [-1], [self.green_color_])
-            self.indicator.publish_led_status()
+        if not self.finished_sampling:
+            # look for the first not blinking led:
+            next_id = self.get_next_off_led()
+            # Split leds depending on total desired fixes on how many leds are available
+            # as long as there are still some leds which are off
+            if (next_id is not None and
+                msg.header.seq
+                >= self.desired_fixes_ / self.indicator.get_num_leds() * next_id
+            ):
+                # add new led blinking and set the one before to on
+                self.indicator.set_led_status([next_id], [4], [self.green_color_])
+                if next_id > 0:
+                    self.indicator.set_led_status([next_id - 1], [-1], [self.green_color_])
+                self.indicator.publish_led_status()
+
+            if msg.header.seq is self.desired_fixes_ -1:
+                # Survey finished
+                self.finished_sampling = True
 
     def set_finish_survey_indicators(self, msg):
-        # Survey finished. Set last led to on and wait for 3 seconds
+        # Set last led to on and wait for 3 seconds
+        num_leds = self.indicator.get_num_leds()
         self.indicator.set_led_status(
-            [self.indicator.get_num_leds() - 1], [-1], [self.green_color_]
+            list(range(0,num_leds)), [-1] * num_leds, [self.green_color_] * num_leds
         )
         self.indicator.publish_led_status()
         rospy.sleep(3)
+        # Survey finsihed can use leds for something else now
+        self.indicator.turn_off_all_leds()
+        self.finished_survey = True
 
-    def set_statelllite_indicators(self, msg):
-        pass
+    def set_satellite_indicators(self, msg):
+        if(self.finished_survey):
+
+            # Assume that 35 satellites is already a lot and threshold for all leds to be on
+            if msg.num_sat > 35:
+                desired_num_leds_on = self.indicator.get_num_leds()
+            else:
+                desired_num_leds_on = int(float(msg.num_sat)/35 * self.indicator.get_num_leds())
+            last_on_led_id = self.get_next_off_led()
+            if last_on_led_id is None:
+                last_on_led_id = self.indicator.get_num_leds()
+            # Check if leds are blinking or not
+            change_blinking_status = False
+            #TODO(clanegge): This does not seem to work
+            """
+            if self.indicator.led_status[0] > 0:
+                # leds are blinking
+                if msg.fix_mode == "SBAS":
+                    change_blinking_status = True
+            elif self.indicator.led_status[0] < 0:
+                # leds are not blinking
+                if msg.fix_mode != "SBAS":
+                    change_blinking_status = True
+            """
+            # Change status only if required (change number of leds or change blinking status)
+            if desired_num_leds_on != last_on_led_id or change_blinking_status:
+                # Turn on desired leds
+                led_status = [-1] * desired_num_leds_on
+                
+                # if we should blink leds change sign
+                if change_blinking_status:
+                    led_status = led_status * (-1)
+
+                # define led ids (here just the range from 0 to desired led)
+                led_id = list(range(0,desired_num_leds_on))
+                
+                # update and publish
+                self.indicator.set_led_status(led_id, led_status, [self.blue_color_] * desired_num_leds_on)
+                self.indicator.publish_led_status()
+

--- a/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator.py
+++ b/piksi_status_indicator/python/piksi_status_indicator/base_station_indicator.py
@@ -2,63 +2,23 @@
 
 import rospy
 from piksi_rtk_msgs.msg import PositionWithCovarianceStamped, ReceiverState_V2_4_1
-from neostate.msg import StatusLEDArray, StatusLED
-
-
-class LEDArray(object):
-    def __init__(self, num_leds):
-        self.__num_of_leds = num_leds
-
-        # LED status:
-        #    0: off
-        #   -1: on
-        #   >0: blinking at frequency specified in array
-        self.__led_status = [0] * self.__num_of_leds
-
-        # Store RGB value for every LED
-        self.__led_colors = [[0, 0, 0]] * self.__num_of_leds
-
-    @property
-    def led_status(self):
-        return self.__led_status
-
-    @property
-    def led_colors(self):
-        return self.__led_colors
-
-    def set_led_status(self, ids, status, rgb_color):
-        if len(ids) is not len(status) is not len(rgb_color):
-            rospy.logwarn(
-                "[Piksi Status Indicator]: " 
-                + "Cannot assign values to ids as their array size is not the same."
-                + "Not changing LED status."
-            )
-            return
-        elif len(ids) > len(self.__led_status):
-            rospy.logwarn(
-                "[Piksi Status Indicator]:"
-                + "It is not possible to assign more values than leds."
-                + "Not changing LED status."
-            )
-            return
-
-        for id, stat_val, color in zip(ids, status, rgb_color):
-            self.__led_status[id] = stat_val
-            if stat_val is not 0:
-                rospy.logwarn("Setting led to color %i", id)
-                self.__led_colors[id] = color
-            else:
-                rospy.logwarn("turning of led %i", id)
-                # turn off led
-                self.__led_colors[id] = [0, 0, 0]
-
-    def get_num_leds(self):
-        return self.__num_of_leds
+from neostate.led_array import LEDArray
 
 
 class BaseStationIndicator(object):
     def __init__(self):
         rospy.init_node("piksi_status_indicator")
+
+        while not rospy.has_param("piksi_multi_cpp_base/num_desired_fixes"):
+            rospy.logwarn_throttle(5, "[Piksi Status Indicator]: Waiting for <num_desired_fixes> param")
+        self.desired_fixes_ = rospy.get_param("piksi_multi_cpp_base/num_desired_fixes")
+
+        num_leds = rospy.get_param("~number_of_leds")
+        self.indicator = LEDArray(num_leds)
+        self.brightness = 0.1
+        self.green_color_ = [0, 10, 0] 
+        self.blue_color_ = [0, 0, 10] 
+
         self.kf_pos_sub_ = rospy.Subscriber(
             "/piksi_multi_cpp_base/base_station_receiver_0/position_sampler/kf_position",
             PositionWithCovarianceStamped,
@@ -78,37 +38,9 @@ class BaseStationIndicator(object):
             queue_size=1,
         )
 
-        self.ind_pub_ = rospy.Publisher("set_status_led_array", StatusLEDArray, queue_size=1, latch=True)
-
-        while not rospy.has_param("piksi_multi_cpp_base/num_desired_fixes"):
-            rospy.logwarn_throttle(5, "[Piksi Status Indicator]: Waiting for <num_desired_fixes> param")
-        self.desired_fixes_ = rospy.get_param("piksi_multi_cpp_base/num_desired_fixes")
-
-        num_leds = rospy.get_param("~number_of_leds")
-        self.indicator = LEDArray(num_leds)
-        self.brightness = 0.1
-        self.green_color_ = [0, 10, 0] 
-        self.blue_color_ = [0, 0, 10] 
-
     def run(self):
         rospy.loginfo("[Piksi Status Indicator]: Starting base station LED indicator..")
         rospy.spin()
-
-    def update_indicator_state(self):
-        msg = StatusLEDArray()
-        for status, color in zip(
-            self.indicator.led_status, self.indicator.led_colors
-        ):
-            led_stat_msg = StatusLED()
-            led_stat_msg.red = color[0]
-            led_stat_msg.green = color[1]
-            led_stat_msg.blue = color[2]
-            if status > 0:
-                led_stat_msg.blinking = True
-            else:
-                led_stat_msg.blinking = False
-            msg.LED_array.append(led_stat_msg)
-        self.ind_pub_.publish(msg)
 
     def set_sampling_indicators(self, msg):
         curr_seq = msg.header.seq
@@ -124,14 +56,14 @@ class BaseStationIndicator(object):
             self.indicator.set_led_status([blink_id], [4], [self.green_color_])
             if blink_id > 0:
                 self.indicator.set_led_status([blink_id - 1], [-1], [self.green_color_])
-            self.update_indicator_state()
+            self.indicator.publish_led_status()
 
     def set_finish_survey_indicators(self, msg):
         # Survey finished. Set last led to on and wait for 3 seconds
         self.indicator.set_led_status(
             [self.indicator.get_num_leds() - 1], [-1], [self.green_color_]
         )
-        self.update_indicator_state()
+        self.indicator.publish_led_status()
         rospy.sleep(3)
 
     def set_statelllite_indicators(self, msg):

--- a/piksi_status_indicator/scripts/start_status_indicator
+++ b/piksi_status_indicator/scripts/start_status_indicator
@@ -1,0 +1,1 @@
+#!/usr/bin/env python

--- a/piksi_status_indicator/scripts/start_status_indicator
+++ b/piksi_status_indicator/scripts/start_status_indicator
@@ -1,1 +1,7 @@
 #!/usr/bin/env python
+
+from piksi_status_indicator.base_station_indicator import BaseStationIndicator
+
+if __name__ == "__main__":
+  indicator = BaseStationIndicator()
+  indicator.run()

--- a/piksi_status_indicator/setup.py
+++ b/piksi_status_indicator/setup.py
@@ -1,0 +1,12 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['piksi_status_indicator'],
+    scripts=['scripts/start_status_indicator'],
+    package_dir={'': 'python'})
+
+setup(**setup_args)


### PR DESCRIPTION
Added a new package that uses the neostate package to set leds of a neopixel and indicate the status of the base station:

- functions as a "loading bar" during sampling where it turns on one led after another to indicate the progress. When done all leds stay green for 3 seconds
- after sampling uses blue leds to indicate how much satellites are being observed at the base station (all leds are blue if more than 35 satellites are being observed)

To make the script launch at startup a script in the install folder can be executed which creates a service for the status indicator and adds an udev rule for the arduino board controlling the leds. 
