### PR TITLE
Feature/disconnection

### DIFF
--- a/piksi_multi_cpp/src/device/device_serial.cc
+++ b/piksi_multi_cpp/src/device/device_serial.cc
@@ -135,8 +135,10 @@ int32_t DeviceSerial::readImpl(uint8_t* buff, uint32_t n) const {
   auto received = sp_blocking_read(port_, buff, n, 10000);
 
   if (received >= 0 && static_cast<uint32_t>(received) < n) {
-    ROS_ERROR("Reading timed out.");
-    return SP_ERR_FAIL;
+    ROS_ERROR_STREAM("Serial read timeout received bytes:"
+                     << received << " requested bytes: " << n
+                     << " device: " << id_);
+    received = SP_ERR_FAIL;
   }
 
   return received;

--- a/piksi_multi_cpp/src/device/device_serial.cc
+++ b/piksi_multi_cpp/src/device/device_serial.cc
@@ -132,7 +132,14 @@ int32_t DeviceSerial::readImpl(uint8_t* buff, uint32_t n) const {
     return 0;
   }
 
-  return sp_blocking_read(port_, buff, n, 10000);
+  auto received = sp_blocking_read(port_, buff, n, 10000);
+
+  if (received >= 0 && static_cast<uint32_t>(received) < n) {
+    ROS_ERROR("Reading timed out.");
+    return SP_ERR_FAIL;
+  }
+
+  return received;
 }
 
 void DeviceSerial::closeImpl() {

--- a/piksi_multi_cpp/src/device/device_tcp.cc
+++ b/piksi_multi_cpp/src/device/device_tcp.cc
@@ -85,14 +85,11 @@ int32_t DeviceTCP::readImpl(uint8_t* buff, uint32_t n) const {
   ssize_t received_length =
       recvfrom(socket_fd_, (void*)buff, n, 0, nullptr, nullptr);
 
-  if (received_length >= 0) {
-    // all good or no data received
-    return received_length;
-  } else {
-    ROS_WARN_STREAM("TCP error " << received_length << " while reading device "
-                                 << id_);
-    return 0;
-  }
+  ROS_ERROR_STREAM_COND(
+      received_length < 0,
+      "TCP error " << received_length << " while reading device " << id_);
+
+  return received_length;
 }
 
 void DeviceTCP::closeImpl() {

--- a/piksi_multi_cpp/src/piksi_multi_node.cc
+++ b/piksi_multi_cpp/src/piksi_multi_node.cc
@@ -29,20 +29,25 @@ int main(int argc, char** argv) {
     }
   }
 
-  // check how many are running.
-  int running_receivers = std::count_if(
-      receivers.begin(), receivers.end(),
-      [](auto receiver) { return receiver.get() && receiver->isRunning(); });
+  // Watchdog to count running receivers.
+  ros::Rate loop_rate(1);
+  while (ros::ok()) {
+    // check how many are running.
+    int running_receivers = std::count_if(
+        receivers.begin(), receivers.end(),
+        [](auto receiver) { return receiver.get() && receiver->isRunning(); });
 
-  if (running_receivers < 1) {
-    ROS_FATAL("No receivers initialized. stopping.");
-    exit(1);
-  } else {
-    ROS_INFO_STREAM("Found and initialized " << running_receivers
-                                             << " Receivers");
+    if (running_receivers < 1) {
+      ROS_FATAL("No receivers initialized. stopping.");
+      exit(1);
+    } else {
+      ROS_INFO_STREAM_ONCE("Found and initialized " << running_receivers
+                                                    << " Receivers");
+    }
+
+    ros::spinOnce();
+    loop_rate.sleep();
   }
-
-  ros::spin();
 
   return 0;
 }

--- a/piksi_multi_cpp/src/piksi_multi_node.cc
+++ b/piksi_multi_cpp/src/piksi_multi_node.cc
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
         [](auto receiver) { return receiver.get() && receiver->isRunning(); });
 
     if (running_receivers < 1) {
-      ROS_FATAL("No receivers initialized. stopping.");
+      ROS_FATAL("No receivers initialized. Stopping.");
       exit(1);
     } else {
       ROS_INFO_STREAM_ONCE("Found and initialized " << running_receivers


### PR DESCRIPTION
This PR addresses https://github.com/ethz-asl/ethz_piksi_ros/issues/149. 

The node now constantly (1Hz) checks whether the reading thread is still running. If a device, Serial,  USB or TCP, times out during read function it properly returns an error and exits the thread.

Tested on USB and TCP devices.

![image](https://user-images.githubusercontent.com/11293852/72798045-7cf28c80-3c42-11ea-9727-f675c57aab75.png)

![image](https://user-images.githubusercontent.com/11293852/72798066-8aa81200-3c42-11ea-8bc9-7fb1fb653523.png)
