### PR TITLE
Feature/ros covariance scale

### DIFF
--- a/libsbp_ros_msgs/include/libsbp_ros_msgs/ros_conversion.h
+++ b/libsbp_ros_msgs/include/libsbp_ros_msgs/ros_conversion.h
@@ -66,13 +66,14 @@ inline void convertNedVector(const NedVectorIn& in, NedPositionOut* out) {
 
 template <class NedAccuracyIn, class NedCovOut>
 inline void convertNedAccuracyToNedCov(const NedAccuracyIn& in,
-                                       NedCovOut* out) {
+                                       const double scale, NedCovOut* out) {
   ROS_ASSERT(out);
   typedef Eigen::Matrix<double, 3, 3, Eigen::RowMajor> Matrix3dRow;
   Matrix3dRow cov = Matrix3dRow::Zero();
   cov(0, 0) = in.h_accuracy * in.h_accuracy * kFromMilli;
   cov(1, 1) = cov(0, 0);
   cov(2, 2) = in.v_accuracy * in.v_accuracy * kFromMilli;
+  cov *= scale;
   Matrix3dRow::Map(out->data()) = cov;
 }
 
@@ -93,61 +94,63 @@ inline void convertWgs84Point(const Wgs84PointIn& in, Eigen::Vector3d* out) {
 }
 
 template <class CartesianCovIn, class CartesianCovOut>
-inline void convertCartesianCov(const CartesianCovIn& in,
+inline void convertCartesianCov(const CartesianCovIn& in, const double scale,
                                 CartesianCovOut* out) {
   ROS_ASSERT(out);
   // First row.
-  (*out)[0] = in.cov_x_x;
-  (*out)[1] = in.cov_x_y;
-  (*out)[2] = in.cov_x_z;
+  (*out)[0] = in.cov_x_x * scale;
+  (*out)[1] = in.cov_x_y * scale;
+  (*out)[2] = in.cov_x_z * scale;
   // Second row.
-  (*out)[3] = in.cov_x_y;
-  (*out)[4] = in.cov_y_y;
-  (*out)[5] = in.cov_y_z;
+  (*out)[3] = in.cov_x_y * scale;
+  (*out)[4] = in.cov_y_y * scale;
+  (*out)[5] = in.cov_y_z * scale;
   // Third row.
-  (*out)[6] = in.cov_x_z;
-  (*out)[7] = in.cov_y_z;
-  (*out)[8] = in.cov_z_z;
+  (*out)[6] = in.cov_x_z * scale;
+  (*out)[7] = in.cov_y_z * scale;
+  (*out)[8] = in.cov_z_z * scale;
 }
 
 template <class CartesianCovIn>
-inline void convertCartesianCov(const CartesianCovIn& in,
+inline void convertCartesianCov(const CartesianCovIn& in, const double scale,
                                 Eigen::Matrix3d* out) {
   ROS_ASSERT(out);
   std::vector<double> cov(9);
-  convertCartesianCov<CartesianCovIn, std::vector<double>>(in, &cov);
+  convertCartesianCov<CartesianCovIn, std::vector<double>>(in, scale, &cov);
   *out = Eigen::Matrix<double, 3, 3, Eigen::RowMajor>(cov.data());
 }
 
 template <class CartesianCovIn, class CartesianCovOut>
-inline void convertCartesianCovMm(const CartesianCovIn& in,
+inline void convertCartesianCovMm(const CartesianCovIn& in, const double scale,
                                   CartesianCovOut* out) {
-  convertCartesianCov<CartesianCovIn, CartesianCovOut>(in, out);
+  convertCartesianCov<CartesianCovIn, CartesianCovOut>(in, scale, out);
   for (auto& cov : *out) {
     cov *= kFromMilliSq;
   }
 }
 
 template <class CovarianceNedIn, class CovarianceNedOut>
-inline void convertNedCov(const CovarianceNedIn& in, CovarianceNedOut* out) {
+inline void convertNedCov(const CovarianceNedIn& in, const double scale,
+                          CovarianceNedOut* out) {
   ROS_ASSERT(out);
   // First row.
-  (*out)[0] = in.cov_n_n;
-  (*out)[1] = in.cov_n_e;
-  (*out)[2] = in.cov_n_d;
+  (*out)[0] = in.cov_n_n * scale;
+  (*out)[1] = in.cov_n_e * scale;
+  (*out)[2] = in.cov_n_d * scale;
   // Second row.
-  (*out)[3] = in.cov_n_e;
-  (*out)[4] = in.cov_e_e;
-  (*out)[5] = in.cov_e_d;
+  (*out)[3] = in.cov_n_e * scale;
+  (*out)[4] = in.cov_e_e * scale;
+  (*out)[5] = in.cov_e_d * scale;
   // Third row.
-  (*out)[6] = in.cov_n_d;
-  (*out)[7] = in.cov_e_d;
-  (*out)[8] = in.cov_d_d;
+  (*out)[6] = in.cov_n_d * scale;
+  (*out)[7] = in.cov_e_d * scale;
+  (*out)[8] = in.cov_d_d * scale;
 }
 
 template <class CovarianceNedIn, class CovarianceNedOut>
-inline void convertNedCovMm(const CovarianceNedIn& in, CovarianceNedOut* out) {
-  convertNedCov<CovarianceNedIn, CovarianceNedOut>(in, out);
+inline void convertNedCovMm(const CovarianceNedIn& in, const double scale,
+                            CovarianceNedOut* out) {
+  convertNedCov<CovarianceNedIn, CovarianceNedOut>(in, scale, out);
   for (auto& cov : *out) {
     cov *= kFromMilliSq;
   }

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_relay.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_relay.h
@@ -44,13 +44,34 @@ class RosRelay : public SBPCallbackHandlerRelay<SbpMsgType, RosMsgType> {
     ros_msg->header.frame_id = frame_id_;
 
     // Manual conversion.
-    if(!convertSbpMsgToRosMsg(sbp_msg, len, ros_msg)) return false;
+    if (!convertSbpMsgToRosMsg(sbp_msg, len, ros_msg)) return false;
     return true;
   }
 
   RosTimeHandler::Ptr ros_time_handler_;
   std::string frame_id_;
 };
+
+template <class SbpMsgType, class RosMsgType>
+class RosCovRelay : public RosRelay<SbpMsgType, RosMsgType> {
+ public:
+  inline RosCovRelay(const ros::NodeHandle& nh, const uint16_t sbp_msg_type,
+                     const std::shared_ptr<sbp_state_t>& state,
+                     const std::string& topic,
+                     const RosTimeHandler::Ptr& ros_time_handler,
+                     const std::string& frame_id)
+      : RosRelay<SbpMsgType, RosMsgType>(nh, sbp_msg_type, state, topic,
+                                         ros_time_handler, frame_id) {
+    ros::NodeHandle nh_node("~");
+    ROS_INFO_COND(nh_node.getParam("ros_cov_scale", cov_scale_),
+                  "Scaling covariance matrix of topic ros/%s by %.1f",
+                  topic.c_str(), cov_scale_);
+  }
+
+ protected:
+  double cov_scale_ = 1.0;
+};
+
 }  // namespace piksi_multi_cpp
 
 #endif  // PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_RELAY_H_

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_relays.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_relays.h
@@ -37,14 +37,14 @@ class RosPosEcefRelay
 };
 
 class RosPosEcefCovRelay
-    : public RosRelay<msg_pos_ecef_cov_t,
-                      piksi_rtk_msgs::PositionWithCovarianceStamped> {
+    : public RosCovRelay<msg_pos_ecef_cov_t,
+                         piksi_rtk_msgs::PositionWithCovarianceStamped> {
  public:
   inline RosPosEcefCovRelay(const ros::NodeHandle& nh,
                             const std::shared_ptr<sbp_state_t>& state,
                             const RosTimeHandler::Ptr& ros_time_handler)
-      : RosRelay(nh, SBP_MSG_POS_ECEF_COV, state, "pos_ecef_cov",
-                 ros_time_handler, "ecef") {}
+      : RosCovRelay(nh, SBP_MSG_POS_ECEF_COV, state, "pos_ecef_cov",
+                    ros_time_handler, "ecef") {}
 
  private:
   bool convertSbpMsgToRosMsg(
@@ -53,14 +53,14 @@ class RosPosEcefCovRelay
 };
 
 class RosPosLlhCovRelay
-    : public RosRelay<msg_pos_llh_cov_t, sensor_msgs::NavSatFix> {
+    : public RosCovRelay<msg_pos_llh_cov_t, sensor_msgs::NavSatFix> {
  public:
   inline RosPosLlhCovRelay(const ros::NodeHandle& nh,
                            const std::shared_ptr<sbp_state_t>& state,
                            const RosTimeHandler::Ptr& ros_time_handler,
                            const RosReceiverState::Ptr& ros_receiver_state)
-      : RosRelay(nh, SBP_MSG_POS_LLH_COV, state, "navsatfix", ros_time_handler,
-                 "wgs84"),
+      : RosCovRelay(nh, SBP_MSG_POS_LLH_COV, state, "navsatfix",
+                    ros_time_handler, "wgs84"),
         ros_receiver_state_(ros_receiver_state) {}
 
  private:
@@ -70,14 +70,14 @@ class RosPosLlhCovRelay
 };
 
 class RosBaselineNedRelay
-    : public RosRelay<msg_baseline_ned_t,
-                      piksi_rtk_msgs::PositionWithCovarianceStamped> {
+    : public RosCovRelay<msg_baseline_ned_t,
+                         piksi_rtk_msgs::PositionWithCovarianceStamped> {
  public:
   inline RosBaselineNedRelay(const ros::NodeHandle& nh,
                              const std::shared_ptr<sbp_state_t>& state,
                              const RosTimeHandler::Ptr& ros_time_handler)
-      : RosRelay(nh, SBP_MSG_BASELINE_NED, state, "baseline_ned",
-                 ros_time_handler, "ned_base_station") {}
+      : RosCovRelay(nh, SBP_MSG_BASELINE_NED, state, "baseline_ned",
+                    ros_time_handler, "ned_base_station") {}
 
  private:
   bool convertSbpMsgToRosMsg(
@@ -100,14 +100,14 @@ class RosVelEcefRelay
 };
 
 class RosVelEcefCovRelay
-    : public RosRelay<msg_vel_ecef_cov_t,
-                      piksi_rtk_msgs::VelocityWithCovarianceStamped> {
+    : public RosCovRelay<msg_vel_ecef_cov_t,
+                         piksi_rtk_msgs::VelocityWithCovarianceStamped> {
  public:
   inline RosVelEcefCovRelay(const ros::NodeHandle& nh,
                             const std::shared_ptr<sbp_state_t>& state,
                             const RosTimeHandler::Ptr& ros_time_handler)
-      : RosRelay(nh, SBP_MSG_VEL_ECEF_COV, state, "vel_ecef_cov",
-                 ros_time_handler, "ecef") {}
+      : RosCovRelay(nh, SBP_MSG_VEL_ECEF_COV, state, "vel_ecef_cov",
+                    ros_time_handler, "ecef") {}
 
  private:
   bool convertSbpMsgToRosMsg(
@@ -130,14 +130,14 @@ class RosVelNedRelay
 };
 
 class RosVelNedCovRelay
-    : public RosRelay<msg_vel_ned_cov_t,
-                      piksi_rtk_msgs::VelocityWithCovarianceStamped> {
+    : public RosCovRelay<msg_vel_ned_cov_t,
+                         piksi_rtk_msgs::VelocityWithCovarianceStamped> {
  public:
   inline RosVelNedCovRelay(const ros::NodeHandle& nh,
                            const std::shared_ptr<sbp_state_t>& state,
                            const RosTimeHandler::Ptr& ros_time_handler)
-      : RosRelay(nh, SBP_MSG_VEL_NED_COV, state, "vel_ned_cov",
-                 ros_time_handler, "ned") {}
+      : RosCovRelay(nh, SBP_MSG_VEL_NED_COV, state, "vel_ned_cov",
+                    ros_time_handler, "ned") {}
 
  private:
   bool convertSbpMsgToRosMsg(

--- a/piksi_multi_cpp/launch/rover.launch
+++ b/piksi_multi_cpp/launch/rover.launch
@@ -15,6 +15,9 @@
 
       	<!-- Autoset ENU origin to startup position. Otherwise it waits for base station position. -->
       	<param name="set_enu_origin_from_current_pos" value="false" />
+
+        <!-- Scales the covariance of the published ROS messages (*/ros/*) -->
+        <param name="ros_cov_scale" value="1.0" />
     </node>
   </group>
 </launch>

--- a/piksi_multi_cpp/launch/rover.launch
+++ b/piksi_multi_cpp/launch/rover.launch
@@ -4,7 +4,7 @@
 
   <!-- The next line allows you to set a predefined ENU frame. -->
   <!--rosparam file="$(find piksi_multi_cpp)/cfg/enu_origin.yaml" /-->
-  
+
   <group ns="$(arg ns)">
     <node name="piksi" pkg="piksi_multi_cpp" type="piksi_multi" output="screen" required="true">
         <param name="device_ids" value="$(arg device_ids)" />

--- a/piksi_multi_cpp/src/sbp_callback_handler/position_sampler.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/position_sampler.cc
@@ -111,7 +111,8 @@ void PositionSampler::callback(uint16_t sender_id, uint8_t len, uint8_t msg[]) {
   Eigen::Vector3d z;
   lrm::convertCartesianPoint<msg_pos_ecef_cov_t>(*sbp_msg, &z);
   Eigen::Matrix3d R;
-  lrm::convertCartesianCov<msg_pos_ecef_cov_t>(*sbp_msg, &R);
+  const double kCovScale = 1.0;
+  lrm::convertCartesianCov<msg_pos_ecef_cov_t>(*sbp_msg, kCovScale, &R);
 
   // Cache least square measurement values.
   size_t block_idx = 3 * num_fixes_++;

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
@@ -40,7 +40,8 @@ bool RosPositionWithCovarianceEnuRelay::convertSbpMsgToRosMsg(
       x_enu_origin_wgs84.x(), x_enu_origin_wgs84.y());
 
   Eigen::Matrix3d cov_ecef;
-  libsbp_ros_msgs::convertCartesianCov<msg_pos_ecef_cov_t>(in, &cov_ecef);
+  libsbp_ros_msgs::convertCartesianCov<msg_pos_ecef_cov_t>(in, cov_scale_,
+                                                           &cov_ecef);
   // https://robotics.stackexchange.com/a/2557
   typedef Eigen::Matrix<double, 3, 3, Eigen::RowMajor> Matrix3dRow;
   Matrix3dRow cov_enu = R_ENU_ECEF * cov_ecef * R_ENU_ECEF.transpose();
@@ -69,7 +70,8 @@ bool RosPoseWithCovarianceEnuRelay::convertSbpMsgToRosMsg(
       x_enu_origin_wgs84.x(), x_enu_origin_wgs84.y());
 
   Eigen::Matrix3d cov_ecef;
-  libsbp_ros_msgs::convertCartesianCov<msg_pos_ecef_cov_t>(in, &cov_ecef);
+  libsbp_ros_msgs::convertCartesianCov<msg_pos_ecef_cov_t>(in, cov_scale_,
+                                                           &cov_ecef);
 
   // https://robotics.stackexchange.com/a/2557
   Eigen::Matrix3d cov_enu = R_ENU_ECEF * cov_ecef * R_ENU_ECEF.transpose();

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_relays.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_relays.cc
@@ -24,7 +24,7 @@ bool RosPosEcefCovRelay::convertSbpMsgToRosMsg(
   lrm::convertCartesianPoint<msg_pos_ecef_cov_t, gm::Point>(
       in, &(out->position.position));
   lrm::convertCartesianCov<msg_pos_ecef_cov_t, boost::array<double, 9>>(
-      in, &(out->position.covariance));
+      in, cov_scale_, &(out->position.covariance));
   return true;
 }
 
@@ -62,7 +62,7 @@ bool RosPosLlhCovRelay::convertSbpMsgToRosMsg(const msg_pos_llh_cov_t& in,
 
   lrm::convertWgs84Point<msg_pos_llh_cov_t, sensor_msgs::NavSatFix>(in, out);
   lrm::convertNedCov<msg_pos_llh_cov_t, boost::array<double, 9>>(
-      in, &(out->position_covariance));
+      in, cov_scale_, &(out->position_covariance));
   out->position_covariance_type = sensor_msgs::NavSatFix::COVARIANCE_TYPE_KNOWN;
 
   return true;
@@ -75,7 +75,7 @@ bool RosBaselineNedRelay::convertSbpMsgToRosMsg(
   lrm::convertNedVector<msg_baseline_ned_t, gm::Point>(
       in, &(out->position.position));
   lrm::convertNedAccuracyToNedCov<msg_baseline_ned_t, boost::array<double, 9>>(
-      in, &(out->position.covariance));
+      in, cov_scale_, &(out->position.covariance));
   return true;
 }
 
@@ -94,7 +94,7 @@ bool RosVelEcefCovRelay::convertSbpMsgToRosMsg(
   lrm::convertCartesianVector<msg_vel_ecef_cov_t, gm::Vector3>(
       in, &(out->velocity.velocity));
   lrm::convertCartesianCovMm<msg_vel_ecef_cov_t, boost::array<double, 9>>(
-      in, &(out->velocity.covariance));
+      in, cov_scale_, &(out->velocity.covariance));
   return true;
 }
 
@@ -113,7 +113,7 @@ bool RosVelNedCovRelay::convertSbpMsgToRosMsg(
   lrm::convertNedVector<msg_vel_ned_cov_t, gm::Vector3>(
       in, &(out->velocity.velocity));
   lrm::convertNedCovMm<msg_vel_ned_cov_t, boost::array<double, 9>>(
-      in, &(out->velocity.covariance));
+      in, cov_scale_, &(out->velocity.covariance));
   return true;
 }
 


### PR DESCRIPTION
This PR introduces a single parameter to scale all ROS messages with covariance information, i.e., all messages that arrive in `*/ros/*cov` namespace. This feature can be useful if the position covariance is too confident for fusion algorithms such as Pixhawk's EKF2.

Example: 
`ros_cov_scale: 1.0`
![scale1](https://user-images.githubusercontent.com/11293852/74452544-86f25e80-4e81-11ea-84c1-37b999db56a5.png)

`ros_cov_scale: 10.0`
![scale10](https://user-images.githubusercontent.com/11293852/74452557-8b1e7c00-4e81-11ea-80fd-772cfab7bffa.png)
