### PR TITLE
Fix/corrections sender

### DIFF
--- a/piksi_multi_cpp/include/piksi_multi_cpp/observations/cb_to_raw_obs_converter.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/observations/cb_to_raw_obs_converter.h
@@ -30,9 +30,12 @@ class CBtoRawObsConverter : public CallbackObservationInterface {
   void observationCallback(msg_heartbeat_t msg) final;
 
   static std::shared_ptr<CBtoRawObsConverter> createFor(
-      const RawObservationInterface::Ptr& consumer) {
+      const RawObservationInterface::Ptr& consumer, const uint16_t sbp_sender_id) {
     auto instance = std::make_shared<CBtoRawObsConverter>();
     instance->raw_consumers_.push_back(consumer);
+
+    // In later piksi versions, this needs to be set.
+    instance->sbp_sender_id_ = sbp_sender_id;
     return instance;
   }
 

--- a/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_base_station.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_base_station.h
@@ -23,6 +23,7 @@ class ReceiverBaseStation : public ReceiverRos {
       const piksi_rtk_msgs::PositionWithCovarianceStamped::Ptr& msg);
   void setupBaseStationSampling();
 
+  uint16_t sbp_sender_id_ {3173};
   ros::ServiceServer resample_base_position_srv_;
   ros::Subscriber ml_estimate_sub_;
   ros::Subscriber receiver_state_sub_;

--- a/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_base_station.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/receiver/receiver_base_station.h
@@ -23,7 +23,7 @@ class ReceiverBaseStation : public ReceiverRos {
       const piksi_rtk_msgs::PositionWithCovarianceStamped::Ptr& msg);
   void setupBaseStationSampling();
 
-  uint16_t sbp_sender_id_ {3173};
+  uint16_t sbp_sender_id_ {0x3173};
   ros::ServiceServer resample_base_position_srv_;
   ros::Subscriber ml_estimate_sub_;
   ros::Subscriber receiver_state_sub_;

--- a/piksi_multi_cpp/src/observations/cb_to_raw_obs_converter.cc
+++ b/piksi_multi_cpp/src/observations/cb_to_raw_obs_converter.cc
@@ -46,7 +46,7 @@ void CBtoRawObsConverter::observationCallback(msg_obs_t_var msg) {
 void CBtoRawObsConverter::observationCallback(msg_heartbeat_t msg) {
   // Repack into full SBP Message
   startMessage();
-  sbp_send_message(&sbp_state_, SBP_MSG_HEARTBEAT, 0x00, sizeof(msg),
+  sbp_send_message(&sbp_state_, SBP_MSG_HEARTBEAT, sbp_sender_id_, sizeof(msg),
                    reinterpret_cast<uint8_t*>(&msg),
                    &CBtoRawObsConverter::sbp_write_redirect);
   // this triggers sbp_write_redirect

--- a/piksi_multi_cpp/src/receiver/receiver_base_station.cc
+++ b/piksi_multi_cpp/src/receiver/receiver_base_station.cc
@@ -52,7 +52,7 @@ void ReceiverBaseStation::setupUDPSenders() {
       udp_sender_->open();
       // Register with observation callbacks
       obs_cbs_->addObservationCallbackListener(
-          CBtoRawObsConverter::createFor(udp_sender_));
+          CBtoRawObsConverter::createFor(udp_sender_, sbp_sender_id_));
     }
   }
 
@@ -66,7 +66,7 @@ void ReceiverBaseStation::setupUDPSenders() {
 
       // Register with observation callbacks
       obs_cbs_->addObservationCallbackListener(
-          CBtoRawObsConverter::createFor(udp_sender_));
+          CBtoRawObsConverter::createFor(udp_sender_, sbp_sender_id_));
     }
   }
 }


### PR DESCRIPTION
Fixes the problem that RTK fix is lost if corrections are received from two independent sources.

What was the issue?
- SBP Protocol has a sender id. This used to be _always_ 0x42 in the past. Now it is actually filled in with the device id
- That means UDP corrections had the 0x42 and RF modem corrections had tth ecorrect base station id, as they are directly generated by the device
- Due to this, the rover received corrections from what looked like two basestations with different ids. Whenever the rover senses a different base station id, the RTK status is reset.

Now it's fixed by hacking in the device id of our current base station. In the future we need to directly read out this ID from the station and store it.

@clanegge  @fabioruetz @alexmillane 