### PR TITLE
Rename base station default host name.

### DIFF
--- a/piksi_multi_cpp/launch/base.launch
+++ b/piksi_multi_cpp/launch/base.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="device_ids" default="usb://*;tcp://piksi:55555"/> <!-- E.g. "usb://*;tcp://192.168.222.0:55555;serial:///dev/ttyS5:115200" -->
+  <arg name="device_ids" default="usb://*;tcp://piksi_base:55555"/> <!-- E.g. "usb://*;tcp://192.168.222.0:55555;serial:///dev/ttyS5:115200" -->
   <node name="piksi_multi_cpp_base" pkg="piksi_multi_cpp" type="piksi_multi" output="screen" required="true">
       <param name="device_ids" value="$(arg device_ids)" />
       <param name="use_gps_time" value="true" />


### PR DESCRIPTION
Changed default TCP address such that users don't start base station accidentally.