### PR TITLE
Use strings for last_{section_setting,setting,value}_read fields

### DIFF
--- a/piksi_multi_rtk_ros/src/piksi_multi_rtk_ros/piksi_multi.py
+++ b/piksi_multi_rtk_ros/src/piksi_multi_rtk_ros/piksi_multi.py
@@ -210,9 +210,9 @@ class PiksiMulti:
             threading.Thread(target=self.ping_base_station_over_wifi).start()
 
         # Handle firmware settings services
-        self.last_section_setting_read = []
-        self.last_setting_read = []
-        self.last_value_read = []
+        self.last_section_setting_read = ""
+        self.last_setting_read = ""
+        self.last_value_read = ""
 
         # Only have start-up reset in base station mode
         if self.base_station_mode:
@@ -1426,9 +1426,9 @@ class PiksiMulti:
         else:
             response.success = False
             response.message = "Please trigger a new 'settings_read_req' via service call."
-            response.section_setting = []
-            response.setting = []
-            response.value = []
+            response.section_setting = ""
+            response.setting = ""
+            response.value = ""
 
         self.clear_last_setting_read()
 
@@ -1588,6 +1588,6 @@ class PiksiMulti:
         self.publishers['mag'].publish(mag_msg)
 
     def clear_last_setting_read(self):
-        self.last_section_setting_read = []
-        self.last_setting_read = []
-        self.last_value_read = []
+        self.last_section_setting_read = ""
+        self.last_setting_read = ""
+        self.last_value_read = ""


### PR DESCRIPTION
This fixes a bug in the settings_read_resp service when a client attempts to retrieve the read response before the response is actually available. In this case, an empty list is assigned to a message field that has a "string" type and ROS refuses to serialize that and returns a generic ROS service exception instead of the intended response with the success field set to False.