### PR TITLE
Removes unused zope.interface dependency

### DIFF
--- a/piksi_multi_rtk_ros/src/piksi_multi_rtk_ros/piksi_multi.py
+++ b/piksi_multi_rtk_ros/src/piksi_multi_rtk_ros/piksi_multi.py
@@ -39,7 +39,6 @@ from sbp.piksi import *  # WARNING: piksi is part of the draft messages, could b
 from sbp.observation import *
 from sbp.orientation import *  # WARNING: orientation messages are still draft messages.
 from sbp.settings import *
-from zope.interface.exceptions import Invalid
 # Piksi Multi features an IMU
 from sbp.imu import *
 # Piksi Multi features a Magnetometer Bosh bmm150 : https://www.bosch-sensortec.com/bst/products/all_products/bmm150


### PR DESCRIPTION
### Overview
The dependency `zope.interface` seems to be unused.  This PR deletes the unused dependency declaration from `piksi_multi_rtk_ros/src/piksi_multi_rtk_ros/piksi_multi.py` 

### How To reproduce
1) install SBP using `piksi_multi_rtk_ros/install/install_piksi_multi.sh`
2) run `catkin_make`
3) `source devel/setup.bash`
4) `roslaunch piksi_multi_rtk_ros piksi_multi_rover.launch`

Fixes #166  
