### PR TITLE
Automatically init ENU origin in Float RTK mode

### DIFF
--- a/piksi_multi_rtk_ros/src/piksi_multi_rtk_ros/piksi_multi.py
+++ b/piksi_multi_rtk_ros/src/piksi_multi_rtk_ros/piksi_multi.py
@@ -777,12 +777,11 @@ class PiksiMulti:
             return
         # RTK messages.
         elif fix_mode == PosLlhMulti.FIX_MODE_FLOAT_RTK:
-            if self.origin_enu_set:
-                self.publish_rtk_float(msg.lat, msg.lon, msg.height, stamp, self.var_rtk_float)
-            else:
-                rospy.logwarn_throttle(5,
-                    "[cb_sbp_pos_llh]: cannot publish float RTK because ENU origin is not set. " +
-                    "Waiting for RTK fix.")
+            # Use first RTK Float to set origin ENU frame, if it was not set by rosparam.
+            if not self.origin_enu_set:
+                self.init_geodetic_reference(msg.lat, msg.lon, msg.height)
+
+            self.publish_rtk_float(msg.lat, msg.lon, msg.height, stamp, self.var_rtk_float)
         elif fix_mode == PosLlhMulti.FIX_MODE_FIX_RTK:
             # Use first RTK fix to set origin ENU frame, if it was not set by rosparam.
             if not self.origin_enu_set:


### PR DESCRIPTION
Just as in RTK Fixed mode, automatically initialize the ENU origin when the first RTK float measurement arrives.