### PR TITLE
Feature/prioritized pps

### DIFF
--- a/piksi_multi_cpp/cfg/config_att_2_3_19.ini
+++ b/piksi_multi_cpp/cfg/config_att_2_3_19.ini
@@ -53,7 +53,7 @@ offset = 0
 propagation_mode = Unlimited
 propagation_timeout = 5
 frequency = 1
-width = 20000
+width = 100
 polarity = 1
 
 [metrics_daemon]

--- a/piksi_pps_sync/install/install.sh
+++ b/piksi_pps_sync/install/install.sh
@@ -36,6 +36,7 @@ cd ..
 sudo apt install chrony -y
 sudo systemctl daemon-reload
 sudo systemctl enable chrony.service
+sudo systemctl disable systemd-timesyncd
 
 echo "Do you wish to append a new PPS refclock to /etc/chrony/chrony.conf? [y or Y to accept]"
 read append_chrony_conf

--- a/piksi_pps_sync/pps-gpio-modprobe/pps-gpio-modprobe.c
+++ b/piksi_pps_sync/pps-gpio-modprobe/pps-gpio-modprobe.c
@@ -44,13 +44,10 @@ static irqreturn_t pps_gpio_irq_handler(int irq, void *data) {
   return IRQ_HANDLED;
 }
 
-static unsigned long get_irqf_trigger_flags(void) {
-  return IRQF_TRIGGER_RISING;
-}
-
 static int pps_gpio_add(void) {
   int pps_default_params;
   int ret;
+  int irq_flags;
 
   /* Copy user params. */
   in_data.gpio = gpio;
@@ -93,6 +90,8 @@ static int pps_gpio_add(void) {
   }
 
   /* Register IRQ interrupt handler */
+  irq_flags = IRQF_TRIGGER_RISING | IRQF_EARLY_RESUME | IRQF_NOBALANCING |
+              IRQF_NO_THREAD;
   ret = request_threaded_irq(in_data.irq, pps_gpio_irq_handler, NULL,
                              get_irqf_trigger_flags(), in_data.info.name,
                              &in_data);
@@ -103,7 +102,8 @@ static int pps_gpio_add(void) {
     return -EINVAL;
   }
 
-  pr_info("Registered GPIO %d as PPS source with IRQ %d\n", in_data.gpio, in_data.irq);
+  pr_info("Registered GPIO %d as PPS source with IRQ %d\n", in_data.gpio,
+          in_data.irq);
   return 0;
 }
 

--- a/piksi_pps_sync/pps-gpio-poll/pps-gpio-poll.c
+++ b/piksi_pps_sync/pps-gpio-poll/pps-gpio-poll.c
@@ -34,7 +34,7 @@ MODULE_PARM_DESC(gpio, "PPS GPIO");
 
 static int pulse_width = 2;
 module_param(pulse_width, int, S_IRUSR);
-MODULE_PARM_DESC(gpio, "PPS pulse width [ms]");
+MODULE_PARM_DESC(pulse_width, "PPS pulse width [ms]");
 
 static int pps_gpio_add(void) {
   int i, ret;


### PR DESCRIPTION
This PR tries to 
- make PPS interrupt more efficient
- disable systemd-timesyncd!!!
- Decrease default PPS width to 100us for attitude receiver to reject strongly delayed PPS interrupts.

On our host computer systemd-timesyncd was messing up the PPS time synchronization.