### PR TITLE
Feature/base pos relay

### DIFF
--- a/piksi_multi_cpp/CMakeLists.txt
+++ b/piksi_multi_cpp/CMakeLists.txt
@@ -28,6 +28,7 @@ cs_add_library(${PROJECT_NAME}
         src/receiver/receiver_ros.cc
         src/receiver/receiver.cc
         src/receiver/settings_io.cc
+        src/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.cc
         src/sbp_callback_handler/sbp_callback_handler_relay/ros_relays.cc
         src/sbp_callback_handler/sbp_callback_handler_relay/ros_imu_relay.cc
         src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.h
@@ -1,0 +1,26 @@
+#ifndef PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_BASE_POS_RELAY_H_
+#define PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_BASE_POS_RELAY_H_
+
+#include <geometry_msgs/PointStamped.h>
+#include <libsbp/navigation.h>
+#include <sensor_msgs/NavSatFix.h>
+#include "piksi_multi_cpp/sbp_callback_handler/geotf_handler.h"
+#include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/sbp_callback_handler_relay.h"
+
+namespace piksi_multi_cpp {
+
+class RosBasePosEcefRelay
+    : public SBPCallbackHandlerRelay<msg_base_pos_ecef_t,
+                                     geometry_msgs::PointStamped> {
+ public:
+  inline RosBasePosEcefRelay(const ros::NodeHandle& nh,
+                             const std::shared_ptr<sbp_state_t>& state);
+
+ private:
+  bool convertSbpToRos(const msg_base_pos_ecef_t& sbp_msg, const uint8_t len,
+                       geometry_msgs::PointStamped* ros_msg) override;
+};
+
+}  // namespace piksi_multi_cpp
+
+#endif  // PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_BASE_POS_RELAY_H_

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.h
@@ -21,6 +21,21 @@ class RosBasePosEcefRelay
                        geometry_msgs::PointStamped* ros_msg) override;
 };
 
+class RosBasePosLlhRelay
+    : public SBPCallbackHandlerRelay<msg_base_pos_ecef_t,
+                                     sensor_msgs::NavSatFix> {
+ public:
+  RosBasePosLlhRelay(const ros::NodeHandle& nh,
+                     const std::shared_ptr<sbp_state_t>& state,
+                     const GeoTfHandler::Ptr& geotf_handler);
+
+ private:
+  bool convertSbpToRos(const msg_base_pos_ecef_t& sbp_msg, const uint8_t len,
+                       sensor_msgs::NavSatFix* ros_msg) override;
+
+  GeoTfHandler::Ptr geotf_handler_;
+};
+
 }  // namespace piksi_multi_cpp
 
 #endif  // PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_BASE_POS_RELAY_H_

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.h
@@ -13,8 +13,8 @@ class RosBasePosEcefRelay
     : public SBPCallbackHandlerRelay<msg_base_pos_ecef_t,
                                      geometry_msgs::PointStamped> {
  public:
-  inline RosBasePosEcefRelay(const ros::NodeHandle& nh,
-                             const std::shared_ptr<sbp_state_t>& state);
+  RosBasePosEcefRelay(const ros::NodeHandle& nh,
+                      const std::shared_ptr<sbp_state_t>& state);
 
  private:
   bool convertSbpToRos(const msg_base_pos_ecef_t& sbp_msg, const uint8_t len,

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
@@ -3,6 +3,7 @@
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_factory.h"
 
+#include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_ext_event_relay.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_imu_relay.h"
@@ -47,6 +48,7 @@ SBPCallbackHandlerFactory::createAllRosMessageRelays(
       SBPCallbackHandler::Ptr(new RosImuRelay(nh, state, ros_time_handler)));
   relays.push_back(
       SBPCallbackHandler::Ptr(new RosMagRelay(nh, state, ros_time_handler)));
+  relays.push_back(SBPCallbackHandler::Ptr(new RosBasePosEcefRelay(nh, state)));
 
   auto ros_receiver_state =
       std::make_shared<RosReceiverState>(nh, state, ros_time_handler);

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
@@ -49,6 +49,8 @@ SBPCallbackHandlerFactory::createAllRosMessageRelays(
   relays.push_back(
       SBPCallbackHandler::Ptr(new RosMagRelay(nh, state, ros_time_handler)));
   relays.push_back(SBPCallbackHandler::Ptr(new RosBasePosEcefRelay(nh, state)));
+  relays.push_back(SBPCallbackHandler::Ptr(
+      new RosBasePosLlhRelay(nh, state, geotf_handler)));
 
   auto ros_receiver_state =
       std::make_shared<RosReceiverState>(nh, state, ros_time_handler);

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.cc
@@ -7,6 +7,7 @@ namespace piksi_multi_cpp {
 
 namespace lrm = libsbp_ros_msgs;
 namespace gm = geometry_msgs;
+namespace sm = sensor_msgs;
 
 RosBasePosEcefRelay::RosBasePosEcefRelay(
     const ros::NodeHandle& nh, const std::shared_ptr<sbp_state_t>& state)
@@ -16,11 +17,44 @@ RosBasePosEcefRelay::RosBasePosEcefRelay(
 bool RosBasePosEcefRelay::convertSbpToRos(const msg_base_pos_ecef_t& sbp_msg,
                                           const uint8_t len,
                                           gm::PointStamped* ros_msg) {
-  ROS_ASSERT(mag);
+  ROS_ASSERT(ros_msg);
 
   ros_msg->header.frame_id = "ecef";
   lrm::convertCartesianPoint<msg_base_pos_ecef_t, gm::Point>(sbp_msg,
                                                              &(ros_msg->point));
+
+  return true;
+}
+
+RosBasePosLlhRelay::RosBasePosLlhRelay(
+    const ros::NodeHandle& nh, const std::shared_ptr<sbp_state_t>& state,
+    const GeoTfHandler::Ptr& geotf_handler)
+    : SBPCallbackHandlerRelay<msg_base_pos_ecef_t, sm::NavSatFix>(
+          nh, SBP_MSG_BASE_POS_ECEF, state, "ros/base_pos_navsatfix"),
+      geotf_handler_(geotf_handler) {}
+
+bool RosBasePosLlhRelay::convertSbpToRos(const msg_base_pos_ecef_t& sbp_msg,
+                                         const uint8_t len,
+                                         sm::NavSatFix* ros_msg) {
+  ROS_ASSERT(ros_msg);
+
+  ros_msg->header.frame_id = "wgs84";
+  ros_msg->status.status = sm::NavSatStatus::STATUS_SBAS_FIX;
+  ros_msg->status.service = sm::NavSatStatus::SERVICE_GPS;
+  ros_msg->status.service |= sm::NavSatStatus::SERVICE_GLONASS;
+  ros_msg->status.service |= sm::NavSatStatus::SERVICE_GALILEO;
+  ros_msg->position_covariance_type = sm::NavSatFix::COVARIANCE_TYPE_UNKNOWN;
+
+  Eigen::Vector3d x_ecef, x_wgs84;
+  lrm::convertCartesianPoint<msg_base_pos_ecef_t>(sbp_msg, &x_ecef);
+
+  if (!geotf_handler_.get()) return false;
+  if (!geotf_handler_->getGeoTf().convert("ecef", x_ecef, "wgs84", &x_wgs84))
+    return false;
+
+  ros_msg->latitude = x_wgs84.x();
+  ros_msg->longitude = x_wgs84.y();
+  ros_msg->altitude = x_wgs84.z();
 
   return true;
 }

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.cc
@@ -1,0 +1,28 @@
+#include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.h"
+
+#include <libsbp_ros_msgs/ros_conversion.h>
+#include <ros/assert.h>
+
+namespace piksi_multi_cpp {
+
+namespace lrm = libsbp_ros_msgs;
+namespace gm = geometry_msgs;
+
+RosBasePosEcefRelay::RosBasePosEcefRelay(
+    const ros::NodeHandle& nh, const std::shared_ptr<sbp_state_t>& state)
+    : SBPCallbackHandlerRelay<msg_base_pos_ecef_t, gm::PointStamped>(
+          nh, SBP_MSG_BASE_POS_ECEF, state, "ros/base_pos_ecef") {}
+
+bool RosBasePosEcefRelay::convertSbpToRos(const msg_base_pos_ecef_t& sbp_msg,
+                                          const uint8_t len,
+                                          gm::PointStamped* ros_msg) {
+  ROS_ASSERT(mag);
+
+  ros_msg->header.frame_id = "ecef";
+  lrm::convertCartesianPoint<msg_base_pos_ecef_t, gm::Point>(sbp_msg,
+                                                             &(ros_msg->point));
+
+  return true;
+}
+
+}  // namespace piksi_multi_cpp


### PR DESCRIPTION
Forward the ECEF and WGS84 base station position to ROS messages. Nice to have in case one wants to quickly introspect the base station position from the rover.

![image](https://user-images.githubusercontent.com/11293852/113178631-10641c00-924f-11eb-984e-5dc7a0998f3d.png)
