### PR TITLE
Feature/time reference

### DIFF
--- a/piksi_multi_cpp/CMakeLists.txt
+++ b/piksi_multi_cpp/CMakeLists.txt
@@ -34,6 +34,7 @@ cs_add_library(${PROJECT_NAME}
         src/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.cc
         src/sbp_callback_handler/sbp_callback_handler_relay/ros_mag_relay.cc
         src/sbp_callback_handler/sbp_callback_handler_relay/ros_receiver_state.cc
+        src/sbp_callback_handler/sbp_callback_handler_relay/ros_time_ref_relay.cc
         src/sbp_callback_handler/geotf_handler.cc
         src/sbp_callback_handler/position_sampler.cc
         src/sbp_callback_handler/ros_time_handler.cc

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_time_ref_relay.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_time_ref_relay.h
@@ -1,0 +1,24 @@
+#ifndef PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_TIME_REF_RELAY_H_
+#define PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_TIME_REF_RELAY_H_
+
+#include <libsbp/navigation.h>
+#include <sensor_msgs/TimeReference.h>
+#include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/sbp_callback_handler_relay.h"
+
+namespace piksi_multi_cpp {
+
+class RosTimeReferenceRelay
+    : public SBPCallbackHandlerRelay<msg_utc_time_t,
+                                     sensor_msgs::TimeReference> {
+ public:
+  RosTimeReferenceRelay(const ros::NodeHandle& nh,
+                        const std::shared_ptr<sbp_state_t>& state);
+
+ private:
+  bool convertSbpToRos(const msg_utc_time_t& sbp_msg, const uint8_t len,
+                       sensor_msgs::TimeReference* ros_msg) override;
+};
+
+}  // namespace piksi_multi_cpp
+
+#endif  // PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_TIME_REF_RELAY_H_

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_factory.cc
@@ -10,6 +10,7 @@
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_mag_relay.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_receiver_state.h"
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_relays.h"
+#include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_time_ref_relay.h"
 
 namespace piksi_multi_cpp {
 
@@ -51,6 +52,8 @@ SBPCallbackHandlerFactory::createAllRosMessageRelays(
   relays.push_back(SBPCallbackHandler::Ptr(new RosBasePosEcefRelay(nh, state)));
   relays.push_back(SBPCallbackHandler::Ptr(
       new RosBasePosLlhRelay(nh, state, geotf_handler)));
+  relays.push_back(
+      SBPCallbackHandler::Ptr(new RosTimeReferenceRelay(nh, state)));
 
   auto ros_receiver_state =
       std::make_shared<RosReceiverState>(nh, state, ros_time_handler);

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_time_ref_relay.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_time_ref_relay.cc
@@ -1,0 +1,46 @@
+#include "piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_time_ref_relay.h"
+
+#include <libsbp_ros_msgs/ros_conversion.h>
+#include <ros/assert.h>
+
+namespace piksi_multi_cpp {
+
+namespace lrm = libsbp_ros_msgs;
+namespace sm = sensor_msgs;
+
+RosTimeReferenceRelay::RosTimeReferenceRelay(
+    const ros::NodeHandle& nh, const std::shared_ptr<sbp_state_t>& state)
+    : SBPCallbackHandlerRelay<msg_utc_time_t, sm::TimeReference>(
+          nh, SBP_MSG_UTC_TIME, state, "ros/time_ref") {}
+
+bool RosTimeReferenceRelay::convertSbpToRos(const msg_utc_time_t& sbp_msg,
+                                            const uint8_t len,
+                                            sm::TimeReference* ros_msg) {
+  ROS_ASSERT(ros_msg);
+
+  ros_msg->header.stamp = ros::Time::now();
+  ros_msg->time_ref = lrm::convertUtcTimeToRosTime(sbp_msg);
+
+  switch (sbp_msg.flags & 0b111) {
+    case 0: {
+      ros_msg->source = "invalid";
+      break;
+    }
+    case 1: {
+      ros_msg->source = "GNSS Solution";
+      break;
+    }
+    case 2: {
+      ros_msg->source = "Propagated";
+      break;
+    }
+    default: {
+      ros_msg->source = "unknown";
+      break;
+    }
+  }
+
+  return true;
+}
+
+}  // namespace piksi_multi_cpp

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_time_ref_relay.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_time_ref_relay.cc
@@ -19,6 +19,7 @@ bool RosTimeReferenceRelay::convertSbpToRos(const msg_utc_time_t& sbp_msg,
   ROS_ASSERT(ros_msg);
 
   ros_msg->header.stamp = ros::Time::now();
+  ros_msg->header.frame_id = "UTC";
   ros_msg->time_ref = lrm::convertUtcTimeToRosTime(sbp_msg);
 
   switch (sbp_msg.flags & 0b111) {


### PR DESCRIPTION
Publish a ROS time ref message.
![image](https://user-images.githubusercontent.com/11293852/113181766-6b4b4280-9252-11eb-8284-a1e7cad2764b.png)

This forwards the current UTC time and the stamp when it was received inside the driver.
![image](https://user-images.githubusercontent.com/11293852/113181859-84ec8a00-9252-11eb-91e8-2ddb8f28a763.png)
