### PR TITLE
Bump geodetic utils.

### DIFF
--- a/piksi_multi_cpp/install/dependencies.rosinstall
+++ b/piksi_multi_cpp/install/dependencies.rosinstall
@@ -1,5 +1,5 @@
 - git: {local-name: catkin_simple, uri: 'git@github.com:catkin/catkin_simple.git'}
 - git: {local-name: libsbp_catkin, uri: 'git@github.com:ethz-asl/libsbp_catkin.git', version: v2.7.4}
-- git: {local-name: geodetic_utils, uri: 'git@github.com:ethz-asl/geodetic_utils.git', version: devel/noetic}
+- git: {local-name: geodetic_utils, uri: 'git@github.com:ethz-asl/geodetic_utils.git', version: 0f6402a5c45fa878c356484c68e6b6c3d888b324}
 - git: {local-name: ethz_piksi_ros, uri: 'git@github.com:ethz-asl/ethz_piksi_ros.git'}
 - git: {local-name: libserialport_catkin, uri: 'git@github.com:ethz-asl/libserialport_catkin.git', version: 0.1.1-4}

--- a/piksi_multi_cpp/install/dependencies_https.rosinstall
+++ b/piksi_multi_cpp/install/dependencies_https.rosinstall
@@ -1,5 +1,5 @@
 - git: {local-name: catkin_simple, uri: 'https://github.com/catkin/catkin_simple.git'}
 - git: {local-name: libsbp_catkin, uri: 'https://github.com/ethz-asl/libsbp_catkin.git', version: v2.7.4}
-- git: {local-name: geodetic_utils, uri: 'https://github.com/ethz-asl/geodetic_utils.git', version: devel/noetic}
+- git: {local-name: geodetic_utils, uri: 'https://github.com/ethz-asl/geodetic_utils.git', version: 0f6402a5c45fa878c356484c68e6b6c3d888b324}
 - git: {local-name: ethz_piksi_ros, uri: 'https://github.com/ethz-asl/ethz_piksi_ros.git'}
 - git: {local-name: libserialport_catkin, uri: 'https://github.com/ethz-asl/libserialport_catkin.git', version: 0.1.1-4}


### PR DESCRIPTION
GDAL lat/lon swap will now be done automatically according to GDAL vsion (Ubuntu 18.04 or Ubuntu 20.04). https://github.com/ethz-asl/geodetic_utils/pull/52