### PR TITLE
Fix/geotf

### DIFF
--- a/libsbp_ros_msgs/CMakeLists.txt
+++ b/libsbp_ros_msgs/CMakeLists.txt
@@ -9,6 +9,11 @@ add_definitions(-DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG)
 find_package(catkin_simple REQUIRED)
 find_package(Eigen3 REQUIRED)
 
+# Workaround to find GeographicLib. With Ubuntu 22.04+ should use GDAL.
+# https://stackoverflow.com/questions/48169653/finding-geographiclib-in-cmake-on-debian
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};/usr/share/cmake/geographiclib")
+find_package(GeographicLib REQUIRED)
+
 ###################
 ## AUTOGENERATION #
 ###################
@@ -29,9 +34,10 @@ catkin_simple(ALL_DEPS_REQUIRED)
 #############
 cs_add_library(${PROJECT_NAME}
   src/conversion.cc
+  src/geo_conversion.cc
   src/ros_conversion.cc
 )
-target_link_libraries(${PROJECT_NAME} Eigen3::Eigen)
+target_link_libraries(${PROJECT_NAME} Eigen3::Eigen ${GeographicLib_LIBRARIES})
 
 #########
 # TESTS #
@@ -40,6 +46,11 @@ catkin_add_gtest(test_ros_conversion
   test/ros-conversion-test.cpp
 )
 target_link_libraries(test_ros_conversion ${PROJECT_NAME})
+
+catkin_add_gtest(test_geo_conversion
+        test/geo-conversion-test.cpp
+        )
+target_link_libraries(test_geo_conversion ${PROJECT_NAME})
 
 cs_install()
 cs_export()

--- a/libsbp_ros_msgs/include/libsbp_ros_msgs/geo_conversion.h
+++ b/libsbp_ros_msgs/include/libsbp_ros_msgs/geo_conversion.h
@@ -30,6 +30,8 @@ class GeographicConversion {
   // (lat, lon, alt), where (lat,lon,alt) are defined w.r.t. WGS84.
   void setEnuFrame(double lat, double lon, double alt);
 
+  void initFromRosParam(const std::string& prefix = "/geotf");
+
  private:
   // Coordinate frame transformations
   std::optional<GeographicLib::LocalCartesian> enu_;

--- a/libsbp_ros_msgs/include/libsbp_ros_msgs/geo_conversion.h
+++ b/libsbp_ros_msgs/include/libsbp_ros_msgs/geo_conversion.h
@@ -1,0 +1,41 @@
+#ifndef LIBSBP_ROS_MSGS_GEO_CONVERSION_H_
+#define LIBSBP_ROS_MSGS_GEO_CONVERSION_H_
+
+#include <Eigen/Dense>
+#include <GeographicLib/Geocentric.hpp>
+#include <GeographicLib/LocalCartesian.hpp>
+#include <optional>
+#include <string>
+
+namespace libsbp_ros_msgs {
+class GeographicConversion {
+ public:
+  GeographicConversion();
+
+  // Converts Position from one input_frame to output_frame.
+  // Order x: latitude, east, y: longitude, north, z: altitude, up
+  bool convertEnuToEcef(const Eigen::Vector3d& enu, Eigen::Vector3d* ecef);
+  bool convertEcefToEnu(const Eigen::Vector3d& ecef, Eigen::Vector3d* enu);
+
+  bool convertEnuToWgs84(const Eigen::Vector3d& enu, Eigen::Vector3d* wgs84);
+  bool convertWgs84ToEnu(const Eigen::Vector3d& wgs84, Eigen::Vector3d* enu);
+
+  void convertEcefToWgs84(const Eigen::Vector3d& ecef, Eigen::Vector3d* wgs84);
+  void convertWgs84ToEcef(const Eigen::Vector3d& wgs84, Eigen::Vector3d* ecef);
+
+  // Check whether ENU frame is set.
+  bool hasEnuFrame();
+
+  // Creates or overwrites the ENU Frame with its origin at the given location
+  // (lat, lon, alt), where (lat,lon,alt) are defined w.r.t. WGS84.
+  void setEnuFrame(double lat, double lon, double alt);
+
+ private:
+  // Coordinate frame transformations
+  std::optional<GeographicLib::LocalCartesian> enu_;
+  const GeographicLib::Geocentric ecef_ = GeographicLib::Geocentric::WGS84();
+};
+
+}  // namespace libsbp_ros_msgs
+
+#endif  // LIBSBP_ROS_MSGS_GEO_CONVERSION_H_

--- a/libsbp_ros_msgs/src/geo_conversion.cc
+++ b/libsbp_ros_msgs/src/geo_conversion.cc
@@ -1,6 +1,7 @@
 #include "libsbp_ros_msgs/geo_conversion.h"
 
 #include <ros/assert.h>
+#include <ros/node_handle.h>
 
 namespace libsbp_ros_msgs {
 
@@ -68,6 +69,42 @@ bool GeographicConversion::hasEnuFrame() { return enu_.has_value(); }
 
 void GeographicConversion::setEnuFrame(double lat, double lon, double alt) {
   enu_.emplace(lat, lon, alt, GeographicLib::Geocentric::WGS84());
+  ROS_INFO("Updated ENU frame with WGS84 (lat, lon, alt): (%.6f, %.6f, %.6f)",
+           lat, lon, alt);
+}
+
+void GeographicConversion::initFromRosParam(const std::string& prefix) {
+  ros::NodeHandle nh;
+  if (!nh.ok() || !nh.hasParam(prefix)) {
+    ROS_WARN("[GeoConversion] No Geodetic Transformations found.");
+    return;
+  }
+  XmlRpc::XmlRpcValue yaml_raw_data;
+  nh.getParam("/geotf", yaml_raw_data);
+
+  auto& frame_definitions = yaml_raw_data["Frames"];
+  for (auto it = frame_definitions.begin(); it != frame_definitions.end();
+       ++it) {
+    const std::string frame_name = it->first;
+    auto& xmlnode = it->second;
+
+    std::string frame_type = xmlnode["Type"];
+    if (frame_type == "ENUOrigin") {
+      if (!xmlnode.hasMember("LatOrigin") || !xmlnode.hasMember("LonOrigin") ||
+          !xmlnode.hasMember("AltOrigin")) {
+        ROS_WARN_STREAM("[GeoConversion] Ignoring frame "
+                        << frame_type
+                        << ": ENU origin needs LatOrigin, LonOrigin and "
+                           "AltOrigin setting.");
+        continue;
+      }
+      double latOrigin = xmlnode["LatOrigin"];
+      double lonOrigin = xmlnode["LonOrigin"];
+      double altOrigin = xmlnode["AltOrigin"];
+
+      setEnuFrame(latOrigin, lonOrigin, altOrigin);
+    }
+  }
 }
 
 }  // namespace libsbp_ros_msgs

--- a/libsbp_ros_msgs/src/geo_conversion.cc
+++ b/libsbp_ros_msgs/src/geo_conversion.cc
@@ -1,0 +1,73 @@
+#include "libsbp_ros_msgs/geo_conversion.h"
+
+#include <ros/assert.h>
+
+namespace libsbp_ros_msgs {
+
+GeographicConversion::GeographicConversion() {}
+
+bool GeographicConversion::convertEnuToEcef(const Eigen::Vector3d& enu,
+                                            Eigen::Vector3d* ecef) {
+  ROS_ASSERT(ecef);
+  Eigen::Vector3d wgs84;
+  if (convertEnuToWgs84(enu, &wgs84)) {
+    convertWgs84ToEcef(wgs84, ecef);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool GeographicConversion::convertEcefToEnu(const Eigen::Vector3d& ecef,
+                                            Eigen::Vector3d* enu) {
+  ROS_ASSERT(enu);
+  Eigen::Vector3d wgs84;
+  convertEcefToWgs84(ecef, &wgs84);
+  return convertWgs84ToEnu(wgs84, enu);
+}
+
+bool GeographicConversion::convertEnuToWgs84(const Eigen::Vector3d& enu,
+                                             Eigen::Vector3d* wgs84) {
+  ROS_ASSERT(wgs84);
+  if (enu_.has_value()) {
+    enu_.value().Reverse(enu.x(), enu.y(), enu.z(), wgs84->x(), wgs84->y(),
+                         wgs84->z());
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool GeographicConversion::convertWgs84ToEnu(const Eigen::Vector3d& wgs84,
+                                             Eigen::Vector3d* enu) {
+  ROS_ASSERT(enu);
+  if (enu_.has_value()) {
+    enu_.value().Forward(wgs84.x(), wgs84.y(), wgs84.z(), enu->x(), enu->y(),
+                         enu->z());
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void GeographicConversion::convertEcefToWgs84(const Eigen::Vector3d& ecef,
+                                              Eigen::Vector3d* wgs84) {
+  ROS_ASSERT(wgs84);
+  ecef_.Reverse(ecef.x(), ecef.y(), ecef.z(), wgs84->x(), wgs84->y(),
+                wgs84->z());
+}
+
+void GeographicConversion::convertWgs84ToEcef(const Eigen::Vector3d& wgs84,
+                                              Eigen::Vector3d* ecef) {
+  ROS_ASSERT(ecef);
+  ecef_.Forward(wgs84.x(), wgs84.y(), wgs84.z(), ecef->x(), ecef->y(),
+                ecef->z());
+}
+
+bool GeographicConversion::hasEnuFrame() { return enu_.has_value(); }
+
+void GeographicConversion::setEnuFrame(double lat, double lon, double alt) {
+  enu_.emplace(lat, lon, alt, GeographicLib::Geocentric::WGS84());
+}
+
+}  // namespace libsbp_ros_msgs

--- a/libsbp_ros_msgs/test/geo-conversion-test.cpp
+++ b/libsbp_ros_msgs/test/geo-conversion-test.cpp
@@ -36,23 +36,20 @@ TEST(GeoConversionTest, SampleGnssPoints) {
   // A couple of sample points logged with Piksi CPP driver.
   // The ENU position is derived from base_pos_ned
   const std::vector<Eigen::Vector3d> enu_measured = {
-      {10.863, 2.435, 1.514},
-      {10.703000, 2.787000, 8.211000},
-      {10.811000, 3.065000, 17.840000},
-      {10.841000, 3.162000, 20.986000},
-      {11.702000, -20.480000, 41.105000}};
+      {10.857000000000001, 2.353, 0.198},
+      {10.036, -17.792, 41.247},
+      {6.317, 5.981, 41.232},
+      {2.852, 39.489000000000004, 41.238}};
   const std::vector<Eigen::Vector3d> wgs84_measured = {
-      {47.381494, 8.576296, 648.879785},
-      {47.381498, 8.576294, 655.576665},
-      {47.381500, 8.576295, 665.205155},
-      {47.381501, 8.576295, 668.351331},
-      {47.381288, 8.576307, 688.470171}};
+      {47.38149370420578, 8.57629557889748, 647.5638267526044},
+      {47.38131252854044, 8.576284714398815, 688.6127781794771},
+      {47.38152633220841, 8.576235472927848, 688.5978165181814},
+      {47.381827687678694, 8.576189587067374, 688.6035694238228}};
   const std::vector<Eigen::Vector3d> ecef_measured = {
-      {4278628.531598, 645271.204977, 4671064.044718},
-      {4278632.782633, 645271.684303, 4671069.211647},
-      {4278639.011154, 645272.732183, 4671076.485160},
-      {4278641.042840, 645273.068989, 4671078.865808},
-      {4278671.587614, 645278.546191, 4671077.662780}};
+      {4278627.710932162, 645271.074246071, 4671063.021060776},
+      {4278669.975769749, 645276.6185371446, 4671079.587635878},
+      {4278653.221991419, 645270.3310393207, 4671095.673600099},
+      {4278629.360581043, 645263.227948546, 4671118.366348593}};
 
   for (size_t i = 0; i < enu_measured.size(); i++) {
     // Test WGS84 <-> ENU
@@ -60,8 +57,9 @@ TEST(GeoConversionTest, SampleGnssPoints) {
     // WGS84 -> ENU
     EXPECT_TRUE(geo_conv.convertWgs84ToEnu(wgs84_measured[i], &enu_from_wgs84));
     EXPECT_TRUE(enu_from_wgs84.isApprox(enu_measured[i], kEnuRes))
-        << "enu_from_wgs84: " << enu_from_wgs84.transpose() << " enu_measured[" << i
-        << "]: " << enu_measured[i].transpose();
+        << "wgs84_measured[" << i << "]: " << wgs84_measured[i].transpose()
+        << " enu_from_wgs84: " << enu_from_wgs84.transpose() << " enu_measured["
+        << i << "]: " << enu_measured[i].transpose();
     EXPECT_TRUE(geo_conv.convertEnuToWgs84(enu_from_wgs84, &wgs84_from_enu));
     EXPECT_TRUE(wgs84_from_enu.isApprox(wgs84_measured[i], kEnuRes));
     // ENU -> WGS84

--- a/libsbp_ros_msgs/test/geo-conversion-test.cpp
+++ b/libsbp_ros_msgs/test/geo-conversion-test.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "libsbp_ros_msgs/geo_conversion.h"
+
+using namespace libsbp_ros_msgs;
+
+const double kRes = 1e-6;
+const double kEnuRes = 1e-3;
+
+TEST(GeoConversionTest, SampleGnssPoints) {
+  GeographicConversion geo_conv;
+
+  EXPECT_FALSE(geo_conv.hasEnuFrame());
+
+  // Data from 2021_04_27_fifa/20210427094114 experiment
+  Eigen::Vector3d base_pos_wgs84 = {47.3814725424, 8.57615182331,
+                                    647.365379524};
+  geo_conv.setEnuFrame(base_pos_wgs84.x(), base_pos_wgs84.y(),
+                       base_pos_wgs84.z());
+  EXPECT_TRUE(geo_conv.hasEnuFrame());
+  Eigen::Vector3d base_pos_ecef_expected = {4278630.909181, 645260.577301,
+                                            4671061.281798};
+
+  // WGS84 to ECEF
+  Eigen::Vector3d base_pose_ecef_calc;
+  geo_conv.convertWgs84ToEcef(base_pos_wgs84, &base_pose_ecef_calc);
+  EXPECT_TRUE(base_pose_ecef_calc.isApprox(base_pos_ecef_expected, kRes));
+
+  // ECEF to WGS84
+  Eigen::Vector3d base_pose_wgs84_calc;
+  geo_conv.convertEcefToWgs84(base_pos_ecef_expected, &base_pose_wgs84_calc);
+  EXPECT_TRUE(base_pose_wgs84_calc.isApprox(base_pos_wgs84, kRes));
+
+  // A couple of sample points logged with Piksi CPP driver.
+  // The ENU position is derived from base_pos_ned
+  const std::vector<Eigen::Vector3d> enu_measured = {
+      {10.863, 2.435, 1.514},
+      {10.703000, 2.787000, 8.211000},
+      {10.811000, 3.065000, 17.840000},
+      {10.841000, 3.162000, 20.986000},
+      {11.702000, -20.480000, 41.105000}};
+  const std::vector<Eigen::Vector3d> wgs84_measured = {
+      {47.381494, 8.576296, 648.879785},
+      {47.381498, 8.576294, 655.576665},
+      {47.381500, 8.576295, 665.205155},
+      {47.381501, 8.576295, 668.351331},
+      {47.381288, 8.576307, 688.470171}};
+  const std::vector<Eigen::Vector3d> ecef_measured = {
+      {4278628.531598, 645271.204977, 4671064.044718},
+      {4278632.782633, 645271.684303, 4671069.211647},
+      {4278639.011154, 645272.732183, 4671076.485160},
+      {4278641.042840, 645273.068989, 4671078.865808},
+      {4278671.587614, 645278.546191, 4671077.662780}};
+
+  for (size_t i = 0; i < enu_measured.size(); i++) {
+    // Test WGS84 <-> ENU
+    Eigen::Vector3d enu_from_wgs84, wgs84_from_enu;
+    // WGS84 -> ENU
+    EXPECT_TRUE(geo_conv.convertWgs84ToEnu(wgs84_measured[i], &enu_from_wgs84));
+    EXPECT_TRUE(enu_from_wgs84.isApprox(enu_measured[i], kEnuRes))
+        << "enu_from_wgs84: " << enu_from_wgs84.transpose() << " enu_measured[" << i
+        << "]: " << enu_measured[i].transpose();
+    EXPECT_TRUE(geo_conv.convertEnuToWgs84(enu_from_wgs84, &wgs84_from_enu));
+    EXPECT_TRUE(wgs84_from_enu.isApprox(wgs84_measured[i], kEnuRes));
+    // ENU -> WGS84
+    EXPECT_TRUE(geo_conv.convertEnuToWgs84(enu_measured[i], &wgs84_from_enu));
+    EXPECT_TRUE(wgs84_from_enu.isApprox(wgs84_measured[i], kEnuRes));
+    EXPECT_TRUE(geo_conv.convertWgs84ToEnu(wgs84_from_enu, &enu_from_wgs84));
+    EXPECT_TRUE(enu_from_wgs84.isApprox(enu_measured[i], kEnuRes));
+
+    // Test ECEF <-> ENU
+    Eigen::Vector3d enu_from_ecef, ecef_from_enu;
+    // ECEF -> ENU
+    EXPECT_TRUE(geo_conv.convertEcefToEnu(ecef_measured[i], &enu_from_ecef));
+    EXPECT_TRUE(enu_from_ecef.isApprox(enu_measured[i], kEnuRes));
+    EXPECT_TRUE(geo_conv.convertEnuToEcef(enu_from_ecef, &ecef_from_enu));
+    EXPECT_TRUE(ecef_from_enu.isApprox(ecef_measured[i], kEnuRes));
+    // ENU -> ECEF
+    EXPECT_TRUE(geo_conv.convertEnuToEcef(enu_measured[i], &ecef_from_enu));
+    EXPECT_TRUE(ecef_from_enu.isApprox(ecef_measured[i], kEnuRes));
+    EXPECT_TRUE(geo_conv.convertEcefToEnu(ecef_from_enu, &enu_from_ecef));
+    EXPECT_TRUE(enu_from_ecef.isApprox(enu_measured[i], kEnuRes));
+
+    // Test WGS84 <-> ECEF
+    Eigen::Vector3d ecef_from_wgs84, wgs84_from_ecef;
+    // WGS84 -> ECEF
+    geo_conv.convertWgs84ToEcef(wgs84_measured[i], &ecef_from_wgs84);
+    EXPECT_TRUE(ecef_from_wgs84.isApprox(ecef_measured[i], kRes));
+    geo_conv.convertEcefToWgs84(ecef_from_wgs84, &wgs84_from_ecef);
+    EXPECT_TRUE(wgs84_from_ecef.isApprox(wgs84_measured[i], kRes));
+    // ECEF -> WGS84
+    geo_conv.convertEcefToWgs84(ecef_measured[i], &wgs84_from_ecef);
+    EXPECT_TRUE(wgs84_from_ecef.isApprox(wgs84_measured[i], kRes));
+    geo_conv.convertWgs84ToEcef(wgs84_from_ecef, &ecef_from_wgs84);
+    EXPECT_TRUE(ecef_from_wgs84.isApprox(ecef_measured[i], kRes));
+  }
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/geotf_handler.h
@@ -1,14 +1,16 @@
 #ifndef PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_GEOTF_HANDLER_H_
 #define PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_GEOTF_HANDLER_H_
 
-#include <geotf/geodetic_converter.h>
 #include <libsbp/navigation.h>
 #include <libsbp_ros_msgs/MsgBasePosEcef.h>
+#include <libsbp_ros_msgs/geo_conversion.h>
 #include <piksi_rtk_msgs/EnuOrigin.h>
 #include <ros/ros.h>
 #include <std_srvs/Empty.h>
+
 #include <Eigen/Dense>
 #include <memory>
+
 #include "piksi_multi_cpp/sbp_callback_handler/sbp_lambda_callback_handler.h"
 
 namespace piksi_multi_cpp {
@@ -28,7 +30,9 @@ class GeoTfHandler {
 
   bool getEnuOriginWgs84(Eigen::Vector3d* enu_origin_wgs84);
 
-  inline geotf::GeodeticConverter getGeoTf() const { return geotf_; }
+  inline libsbp_ros_msgs::GeographicConversion getGeoTf() const {
+    return geotf_;
+  }
 
   GeoTfHandler(GeoTfHandler const&) = delete;
   void operator=(GeoTfHandler const&) = delete;
@@ -44,7 +48,7 @@ class GeoTfHandler {
                                   std_srvs::Empty::Response& res);
 
   SBPLambdaCallbackHandler<msg_pos_llh_t> pos_llh_handler_;
-  geotf::GeodeticConverter geotf_;
+  libsbp_ros_msgs::GeographicConversion geotf_;
 
   ros::NodeHandle nh_;
   ros::ServiceServer set_enu_origin_srv_;

--- a/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
+++ b/piksi_multi_cpp/include/piksi_multi_cpp/sbp_callback_handler/sbp_callback_handler_relay/ros_enu_relays.h
@@ -1,7 +1,6 @@
 #ifndef PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_ENU_RELAYS_H_
 #define PIKSI_MULTI_CPP_SBP_CALLBACK_HANDLER_SBP_CALLBACK_HANDLER_RELAY_ROS_ENU_RELAYS_H_
 
-#include <geotf/geodetic_converter.h>
 #include <libsbp/navigation.h>
 #include <ros/assert.h>
 #include <Eigen/Dense>
@@ -10,6 +9,7 @@
 #include <geometry_msgs/Point.h>
 #include <geometry_msgs/PointStamped.h>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <geometry_msgs/TransformStamped.h>
 #include <geometry_msgs/Vector3.h>
 #include <piksi_rtk_msgs/PositionWithCovarianceStamped.h>
 
@@ -47,7 +47,7 @@ class RosEnuRelay : public RosRelay<SbpMsgType, RosMsgType> {
     libsbp_ros_msgs::convertCartesianPoint<SbpMsgType>(in, &x_ecef);
 
     if (!geotf_handler_.get()) return false;
-    if (!geotf_handler_->getGeoTf().convert("ecef", x_ecef, "enu", x_enu))
+    if (!geotf_handler_->getGeoTf().convertEcefToEnu(x_ecef, x_enu))
       return false;
 
     return true;

--- a/piksi_multi_cpp/install/dependencies_https.rosinstall
+++ b/piksi_multi_cpp/install/dependencies_https.rosinstall
@@ -1,5 +1,4 @@
 - git: {local-name: catkin_simple, uri: 'https://github.com/catkin/catkin_simple.git'}
 - git: {local-name: libsbp_catkin, uri: 'https://github.com/ethz-asl/libsbp_catkin.git', version: v2.7.4}
-- git: {local-name: geodetic_utils, uri: 'https://github.com/ethz-asl/geodetic_utils.git', version: 0f6402a5c45fa878c356484c68e6b6c3d888b324}
 - git: {local-name: ethz_piksi_ros, uri: 'https://github.com/ethz-asl/ethz_piksi_ros.git'}
 - git: {local-name: libserialport_catkin, uri: 'https://github.com/ethz-asl/libserialport_catkin.git', version: 0.1.1-4}

--- a/piksi_multi_cpp/install/prepare-jenkins-slave.sh
+++ b/piksi_multi_cpp/install/prepare-jenkins-slave.sh
@@ -8,15 +8,11 @@ sudo apt install -y python3-wstool python3-catkin-tools
 
 # Package dependencies.
 echo "Installing libsbp_ros_msgs dependencies."
-sudo apt install -y python3-pip libeigen3-dev libgoogle-glog-dev libgtest-dev
+sudo apt install -y python3-pip libeigen3-dev libgoogle-glog-dev libgtest-dev libgeographic-dev
 sudo apt install -y ros-${ROS_VERSION}-genmsg
 pip3 install jinja2
 pip3 install setuptools
 pip3 install voluptuous
-
-echo "Installing geodetic_utils and geotf dependencies."
-sudo apt install ros-${ROS_VERSION}-tf-conversions -y
-sudo apt install libgdal-dev -y
 
 echo "Installing piksi_rtk_msgs dependencies."
 sudo apt install ros-${ROS_VERSION}-rospy \

--- a/piksi_multi_cpp/package.xml
+++ b/piksi_multi_cpp/package.xml
@@ -21,7 +21,6 @@
   <depend>sensor_msgs</depend>
   <depend>eigen_conversions</depend>
   <depend>roslib</depend>
-  <depend>geotf</depend>
 
   <depend>libserialport_catkin</depend>
 </package>

--- a/piksi_multi_cpp/src/receiver/receiver_base_station.cc
+++ b/piksi_multi_cpp/src/receiver/receiver_base_station.cc
@@ -116,10 +116,7 @@ void ReceiverBaseStation::sampledPositionCallback(
 
   Eigen::Vector3d x_ecef, x_wgs84;
   tf::pointMsgToEigen(msg->position.position, x_ecef);
-  if (!geotf_handler_->getGeoTf().convert("ecef", x_ecef, "wgs84", &x_wgs84)) {
-    ROS_ERROR("Failed to convert ECEF to WGS84.");
-    return;
-  }
+  geotf_handler_->getGeoTf().convertEcefToWgs84(x_ecef, &x_wgs84);
 
   ROS_INFO("Writing lat: %.9f lon: %.9f alt: %.9f to %s.", x_wgs84.x(),
            x_wgs84.y(), x_wgs84.z(), nh_.getUnresolvedNamespace().c_str());

--- a/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.cc
+++ b/piksi_multi_cpp/src/sbp_callback_handler/sbp_callback_handler_relay/ros_base_pos_relay.cc
@@ -49,8 +49,7 @@ bool RosBasePosLlhRelay::convertSbpToRos(const msg_base_pos_ecef_t& sbp_msg,
   lrm::convertCartesianPoint<msg_base_pos_ecef_t>(sbp_msg, &x_ecef);
 
   if (!geotf_handler_.get()) return false;
-  if (!geotf_handler_->getGeoTf().convert("ecef", x_ecef, "wgs84", &x_wgs84))
-    return false;
+  geotf_handler_->getGeoTf().convertEcefToWgs84(x_ecef, &x_wgs84);
 
   ros_msg->latitude = x_wgs84.x();
   ros_msg->longitude = x_wgs84.y();


### PR DESCRIPTION
Problem: The conversion from SBP ECEF or WGS84 measurement to ENU with geotf was erroneous because of the projection type geotf uses (see https://github.com/ethz-asl/geodetic_utils/issues/53).

In this PR we replace geotf by geographiclib which gives conversions between ECEF<->WGS84<->ENU. 

We tested this PR with historic data in a unit test as well as on the hardware. Here we set up the base station approximately 250m away from the rover and set the base station antenna position to be the ENU origin. `pos_enu` published by our driver and `baseline_ned` published by Piksi should now coincide. 

**OLD master**
```
/rover/piksi/position_receiver_0/ros/pos_enu
  east: 46.169826148400524
  north: -244.57162264061503
  up: -4.039364604279399
```

```
/rover/piksi/position_receiver_0/ros/baseline_ned
  east: 46.257
  north: -244.28
  up: -4.0440000000000005
```

Difference: `0.304` **This is terrible!**

**New fix/geotf**
```
/rover/piksi/position_receiver_0/ros/pos_enu
  east: 46.27259394353746
  north: -244.25576613787558
  up: -4.042596601441858
```

```
/rover/piksi/position_receiver_0/ros/baseline_ned
  east: 46.273
  north: -244.256
  up: -4.043
```

Difference: `0.0006` **This is excellent!** It is within the mm resolution of baseline_ned.

This PR closes https://github.com/ethz-asl/ethz_piksi_ros/issues/227